### PR TITLE
Add composable Gen class for type-safe generator composition

### DIFF
--- a/src/typedlogic/__init__.py
+++ b/src/typedlogic/__init__.py
@@ -21,7 +21,7 @@ from typedlogic.datamodel import (
     Variable,
 )
 from typedlogic.pybridge import FactMixin, Fact
-from typedlogic.generators import gen, gen1, gen2, gen3
+from typedlogic.generators import gen, gen1, gen2, gen3, Gen, gen_range, gen_list, gen_const, gen_product
 from typedlogic.decorators import axiom, goal
 
 __all__ = [
@@ -50,4 +50,9 @@ __all__ = [
     "gen1",
     "gen2",
     "gen3",
+    "Gen",
+    "gen_range",
+    "gen_list",
+    "gen_const",
+    "gen_product",
 ]

--- a/src/typedlogic/generators.py
+++ b/src/typedlogic/generators.py
@@ -29,13 +29,33 @@ Note that while the semantics of the above program are consistent with Python se
 actually executing the above code would take infinite time as there are infinite strings.
 Instead, the python is treated as a logical specification.
 
+Composable Generators:
+----------------------
+You can also use the composable `Gen` class to define generators with type-safe composition:
+
+```python
+@axiom
+def ancestor_transitivity_axiom() -> bool:
+    '''For all x,y,z, if AncestorOf(x,z) and AncestorOf(z,y), then AncestorOf(x,y)'''
+    return all(
+        AncestorOf(ancestor=x, descendant=y)
+        for x, y, z in Gen(TreeNodeType) * Gen(TreeNodeType) * Gen(TreeNodeType)
+        if AncestorOf(ancestor=x, descendant=z) and AncestorOf(ancestor=z, descendant=y)
+    )
+```
+
+The `*` operator creates a cartesian product of generators, maintaining type information
+for the parser.
+
 """
-from typing import Any, Generator, Tuple, Type, TypeVar
+from itertools import islice
+from typing import Any, Callable, Generator, Generic, Iterator, List, Tuple, Type, TypeVar, Union
 
 T = TypeVar("T")
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
 T3 = TypeVar("T3")
+U = TypeVar("U")
 
 
 def gen(*types: Type[Any]) -> Generator[Tuple[Any, ...], None, None]:
@@ -93,3 +113,253 @@ def gen3(type1: Type[T1], type2: Type[T2], type3: Type[T3]) -> Generator[Tuple[T
     """
     while True:
         yield type1(), type2(), type3()  # Replace with actual logic
+
+
+class Gen(Generic[T]):
+    """
+    A composable generator with type signatures for logical specifications.
+
+    This class enables creating type-safe, composable generators that can be combined
+    using operators like `*` (cartesian product) and `+` (interleaving).
+
+    .. note:: Like the gen1/gen2/gen3 functions, Gen is used for logical specifications
+              and is parsed by the AST parser rather than executed directly.
+
+    Example:
+    --------
+    ```python
+    @axiom
+    def my_axiom() -> bool:
+        return all(
+            P(x, y, z)
+            for x, y, z in Gen(str) * Gen(int) * Gen(float)
+            if Q(x, y)
+        )
+    ```
+
+    :param type_or_factory: Either a type (for logical specifications) or a callable
+                            that returns an iterator (for runtime execution)
+    """
+
+    def __init__(
+        self,
+        type_or_factory: Union[Type[T], Callable[[], Iterator[T]]],
+    ):
+        """
+        Initialize a generator.
+
+        :param type_or_factory: Either a Type for specification purposes, or a callable
+                                that returns an iterator for runtime execution
+        """
+        if isinstance(type_or_factory, type):
+            # Store the type for AST parsing
+            self._type: Type[T] = type_or_factory
+            self._types: Tuple[Type[Any], ...] = (type_or_factory,)
+            # Create a simple factory that instantiates the type
+            self._factory: Callable[[], Iterator[T]] = lambda: self._infinite_type_iter(type_or_factory)
+        else:
+            # It's a factory function
+            self._type = None  # type: ignore[assignment]
+            self._types = ()
+            self._factory = type_or_factory
+
+    @staticmethod
+    def _infinite_type_iter(t: Type[T]) -> Iterator[T]:
+        """Generate infinite instances of a type (for specification purposes)."""
+        while True:
+            yield t()
+
+    @property
+    def types(self) -> Tuple[Type[Any], ...]:
+        """Return the tuple of types this generator produces."""
+        return self._types
+
+    def __iter__(self) -> Iterator[T]:
+        """Return a fresh iterator."""
+        return self._factory()
+
+    def __mul__(self, other: "Gen[U]") -> "Gen[Tuple[T, U]]":
+        """
+        Combine two generators to produce a cartesian product.
+
+        The result flattens nested tuples so that `Gen(A) * Gen(B) * Gen(C)` yields
+        `(a, b, c)` rather than `((a, b), c)`.
+
+        Example:
+        --------
+        ```python
+        Gen(int) * Gen(str)  # produces Iterator[Tuple[int, str]]
+        Gen(int) * Gen(str) * Gen(float)  # produces Iterator[Tuple[int, str, float]]
+        ```
+
+        :param other: Another Gen to combine with
+        :return: A new Gen producing tuples from the cartesian product
+        """
+
+        def combined() -> Iterator[Tuple[Any, ...]]:
+            for left in self:
+                for right in other:
+                    # Flatten: if left is already a tuple from a previous *, extend it
+                    if isinstance(left, tuple):
+                        yield (*left, right)
+                    else:
+                        yield (left, right)
+
+        result: Gen[Tuple[T, U]] = Gen(combined)  # type: ignore[arg-type]
+        # Combine types from both generators
+        result._types = self._types + other._types
+        return result
+
+    def __add__(self, other: "Gen[T]") -> "Gen[T]":
+        """
+        Interleave two generators.
+
+        Elements are yielded alternating from each generator until one is exhausted,
+        then remaining elements from the other generator are yielded.
+
+        Example:
+        --------
+        ```python
+        gen1 + gen2  # produces elements alternating from both
+        ```
+
+        :param other: Another Gen to interleave with
+        :return: A new Gen with interleaved elements
+        """
+
+        def combined() -> Iterator[T]:
+            iter1, iter2 = iter(self), iter(other)
+            while True:
+                try:
+                    yield next(iter1)
+                except StopIteration:
+                    yield from iter2
+                    break
+                try:
+                    yield next(iter2)
+                except StopIteration:
+                    yield from iter1
+                    break
+
+        result = Gen(combined)  # type: ignore[arg-type]
+        result._types = self._types  # Keep same types (assuming same type for +)
+        return result
+
+    def map(self, f: Callable[[T], U]) -> "Gen[U]":
+        """
+        Apply a function to each element.
+
+        :param f: A function to apply to each element
+        :return: A new Gen with the function applied
+        """
+
+        def mapped() -> Iterator[U]:
+            return (f(x) for x in self)
+
+        result = Gen(mapped)  # type: ignore[arg-type]
+        return result
+
+    def filter(self, predicate: Callable[[T], bool]) -> "Gen[T]":
+        """
+        Filter elements by a predicate.
+
+        :param predicate: A function returning True for elements to keep
+        :return: A new Gen with only matching elements
+        """
+
+        def filtered() -> Iterator[T]:
+            return (x for x in self if predicate(x))
+
+        result: Gen[T] = Gen(filtered)  # type: ignore[arg-type]
+        result._types = self._types
+        return result
+
+    def take(self, n: int) -> "Gen[T]":
+        """
+        Take first n elements.
+
+        :param n: Number of elements to take
+        :return: A new Gen yielding at most n elements
+        """
+
+        def limited() -> Iterator[T]:
+            return islice(self, n)
+
+        result: Gen[T] = Gen(limited)  # type: ignore[arg-type]
+        result._types = self._types
+        return result
+
+    def __repr__(self) -> str:
+        if self._types:
+            type_names = ", ".join(t.__name__ if hasattr(t, "__name__") else str(t) for t in self._types)
+            return f"Gen({type_names})"
+        return "Gen(<factory>)"
+
+
+def gen_range(start: int, end: int) -> Gen[int]:
+    """
+    Generate integers in a range [start, end).
+
+    :param start: Start of range (inclusive)
+    :param end: End of range (exclusive)
+    :return: A Gen yielding integers in the range
+    """
+    return Gen(lambda: iter(range(start, end)))
+
+
+def gen_list(items: List[T]) -> Gen[T]:
+    """
+    Generate from a list (cycles through it infinitely).
+
+    :param items: List of items to cycle through
+    :return: A Gen yielding items from the list
+    """
+
+    def factory() -> Iterator[T]:
+        if not items:
+            return
+        while True:
+            yield from items
+
+    return Gen(factory)
+
+
+def gen_const(value: T) -> Gen[T]:
+    """
+    Generate the same value infinitely.
+
+    :param value: The value to yield
+    :return: A Gen yielding the value infinitely
+    """
+
+    def factory() -> Iterator[T]:
+        while True:
+            yield value
+
+    return Gen(factory)
+
+
+def gen_product(*gens: Gen[Any]) -> Gen[Tuple[Any, ...]]:
+    """
+    Combine N generators into a single generator of tuples (cartesian product).
+
+    This is a helper function that combines multiple generators using the `*` operator.
+
+    Example:
+    --------
+    ```python
+    gen_product(Gen(int), Gen(str), Gen(float))
+    # equivalent to: Gen(int) * Gen(str) * Gen(float)
+    ```
+
+    :param gens: Variable number of Gen instances
+    :return: A Gen producing tuples from the cartesian product
+    """
+    if not gens:
+        return Gen(lambda: iter([()]))
+
+    result = gens[0]
+    for g in gens[1:]:
+        result = result * g
+
+    return result  # type: ignore[return-value]

--- a/src/typedlogic/parsers/pyparser/python_ast_utils.py
+++ b/src/typedlogic/parsers/pyparser/python_ast_utils.py
@@ -235,8 +235,10 @@ def parse_generator_node(node: ast.GeneratorExp) -> Tuple[List[Variable], Senten
     """
     Parse a generator expression node and return the arguments and the implied sentence.
 
-    :param node:
-    :return:
+    Supports both legacy gen1/gen2/gen3 calls and the new composable Gen(T) * Gen(T) syntax.
+
+    :param node: A generator expression AST node
+    :return: Tuple of (list of Variables, the Sentence from the generator body)
     """
     elt = node.elt
     gens = node.generators
@@ -244,11 +246,18 @@ def parse_generator_node(node: ast.GeneratorExp) -> Tuple[List[Variable], Senten
         raise ValueError(f"Unsupported number of generators: {len(gens)}")
     gen = gens[0]
     iter_node = gen.iter
+
+    # Parse the iterator to extract types
     if isinstance(iter_node, ast.Call):
+        # Legacy gen1/gen2/gen3(Type) or single Gen(Type)
         iter_func, iter_args = parse_gen_call(iter_node)
+    elif isinstance(iter_node, ast.BinOp) and isinstance(iter_node.op, ast.Mult):
+        # Composable Gen(T1) * Gen(T2) * ... syntax
+        iter_args = parse_composable_gen(iter_node)
     else:
-        # iter_func = ast.unparse(iter_node)
+        # Unknown iterator format
         iter_args = []
+
     if gen.ifs:
         if_exprs = [parse_sentence(if_node) for if_node in gen.ifs]
         if_conj = if_exprs[0]
@@ -257,15 +266,16 @@ def parse_generator_node(node: ast.GeneratorExp) -> Tuple[List[Variable], Senten
     else:
         if_conj = None
 
-    # arg_types = {}
+    # Build the variable bindings from target and iter_args
     if isinstance(gen.target, ast.Name):
-        arg_types = {gen.target.id: Variable(gen.target.id, iter_args[0])}
+        arg_types = {gen.target.id: Variable(gen.target.id, iter_args[0] if iter_args else None)}
     elif isinstance(gen.target, ast.Tuple):
         arg_types = {}
         for i, xelt in enumerate(gen.target.elts):
             if not isinstance(xelt, ast.Name):
-                raise ValueError(f"Unsupported target type: {type(elt)}")
-            arg_types[xelt.id] = Variable(xelt.id, iter_args[i])
+                raise ValueError(f"Unsupported target type: {type(xelt)}")
+            domain = iter_args[i] if i < len(iter_args) else None
+            arg_types[xelt.id] = Variable(xelt.id, domain)
     else:
         raise ValueError(f"Unsupported target type: {type(gen.target)}")
 
@@ -297,6 +307,40 @@ def parse_gen_call(node: ast.Call) -> tuple[str, List[str]]:
     func_name = node.func.id if isinstance(node.func, ast.Name) else str(node.func)
     args = [ast.unparse(arg) for arg in node.args]
     return func_name, args
+
+
+def parse_composable_gen(node: ast.expr) -> List[str]:
+    """
+    Parse composable generator expressions like `Gen(T1) * Gen(T2) * Gen(T3)`.
+
+    Handles both simple Gen(Type) calls and binary multiplication operations
+    that chain multiple Gen() calls together.
+
+    :param node: An AST expression node (Call or BinOp)
+    :return: List of type names in order
+    :raises ValueError: If the expression is not a valid composable generator
+    """
+    if isinstance(node, ast.Call):
+        # Single Gen(Type) call
+        func_name = get_func_name(node.func)
+        if func_name == "Gen":
+            if len(node.args) != 1:
+                raise ValueError(f"Gen() expects exactly 1 argument, got {len(node.args)}")
+            return [ast.unparse(node.args[0])]
+        elif func_name in ("gen", "gen1", "gen2", "gen3"):
+            # Handle legacy gen functions
+            return [ast.unparse(arg) for arg in node.args]
+        else:
+            raise ValueError(f"Unknown generator function: {func_name}")
+
+    elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.Mult):
+        # Gen(T1) * Gen(T2) - multiplication chain
+        left_types = parse_composable_gen(node.left)
+        right_types = parse_composable_gen(node.right)
+        return left_types + right_types
+
+    else:
+        raise ValueError(f"Unsupported generator expression: {ast.unparse(node)}")
 
 
 def parse_func(node: ast.Call) -> tuple[str, List[str]]:

--- a/tests/test_generators.py
+++ b/tests/test_generators.py
@@ -1,0 +1,179 @@
+"""
+Tests for the composable Gen class.
+
+These tests verify both the runtime behavior of Gen (for practical use cases)
+and ensure the type tracking works correctly for AST parsing.
+"""
+from typedlogic.generators import Gen, gen_const, gen_list, gen_product, gen_range
+
+
+class TestGenBasic:
+    """Test basic Gen functionality."""
+
+    def test_gen_with_type(self):
+        """Test creating a Gen with a type."""
+        g = Gen(int)
+        assert g.types == (int,)
+        assert repr(g) == "Gen(int)"
+
+    def test_gen_with_callable(self):
+        """Test creating a Gen with a factory function."""
+        g = Gen(lambda: iter([1, 2, 3]))
+        result = list(g)
+        assert result == [1, 2, 3]
+
+    def test_gen_iteration(self):
+        """Test that Gen is iterable."""
+        g = gen_range(0, 5)
+        result = list(g)
+        assert result == [0, 1, 2, 3, 4]
+
+
+class TestGenComposition:
+    """Test Gen composition with operators."""
+
+    def test_mul_two_gens(self):
+        """Test cartesian product with * operator."""
+        g1 = gen_range(1, 3)
+        g2 = gen_range(10, 12)
+        combined = g1 * g2
+
+        result = list(combined)
+        expected = [(1, 10), (1, 11), (2, 10), (2, 11)]
+        assert result == expected
+
+    def test_mul_three_gens_flat(self):
+        """Test that chained * produces flat tuples."""
+        g1 = gen_range(1, 2)  # [1]
+        g2 = gen_range(10, 11)  # [10]
+        g3 = gen_range(100, 101)  # [100]
+        combined = g1 * g2 * g3
+
+        result = list(combined)
+        assert result == [(1, 10, 100)]
+
+    def test_mul_preserves_types(self):
+        """Test that * preserves type information."""
+        g1 = Gen(int)
+        g2 = Gen(str)
+        g3 = Gen(float)
+        combined = g1 * g2 * g3
+
+        assert combined.types == (int, str, float)
+
+    def test_add_interleave(self):
+        """Test interleaving with + operator."""
+        g1 = gen_range(1, 4)  # 1, 2, 3
+        g2 = gen_range(10, 13)  # 10, 11, 12
+        combined = g1 + g2
+
+        result = list(combined)
+        assert result == [1, 10, 2, 11, 3, 12]
+
+    def test_add_unequal_lengths(self):
+        """Test interleaving with different length generators."""
+        g1 = gen_range(1, 3)  # 1, 2
+        g2 = gen_range(10, 14)  # 10, 11, 12, 13
+        combined = g1 + g2
+
+        result = list(combined)
+        assert result == [1, 10, 2, 11, 12, 13]
+
+
+class TestGenTransformations:
+    """Test Gen transformation methods."""
+
+    def test_map(self):
+        """Test mapping a function over Gen elements."""
+        g = gen_range(1, 4)
+        mapped = g.map(lambda x: x * 2)
+
+        result = list(mapped)
+        assert result == [2, 4, 6]
+
+    def test_filter(self):
+        """Test filtering Gen elements."""
+        g = gen_range(1, 10)
+        filtered = g.filter(lambda x: x % 2 == 0)
+
+        result = list(filtered)
+        assert result == [2, 4, 6, 8]
+
+    def test_take(self):
+        """Test taking first n elements."""
+        g = gen_range(0, 100)
+        taken = g.take(5)
+
+        result = list(taken)
+        assert result == [0, 1, 2, 3, 4]
+
+    def test_chained_transformations(self):
+        """Test chaining multiple transformations."""
+        g = gen_range(1, 20)
+        result = list(g.filter(lambda x: x % 2 == 0).map(lambda x: x * 10).take(3))
+
+        assert result == [20, 40, 60]
+
+
+class TestHelperFunctions:
+    """Test helper generator functions."""
+
+    def test_gen_range(self):
+        """Test gen_range helper."""
+        g = gen_range(5, 10)
+        result = list(g)
+        assert result == [5, 6, 7, 8, 9]
+
+    def test_gen_list(self):
+        """Test gen_list helper with finite iteration."""
+        g = gen_list([1, 2, 3])
+        result = list(g.take(7))
+        assert result == [1, 2, 3, 1, 2, 3, 1]
+
+    def test_gen_list_empty(self):
+        """Test gen_list with empty list."""
+        g = gen_list([])
+        result = list(g)
+        assert result == []
+
+    def test_gen_const(self):
+        """Test gen_const helper."""
+        g = gen_const(42)
+        result = list(g.take(5))
+        assert result == [42, 42, 42, 42, 42]
+
+    def test_gen_product(self):
+        """Test gen_product helper."""
+        g = gen_product(gen_range(1, 2), gen_range(10, 11), gen_range(100, 101))
+        result = list(g)
+        assert result == [(1, 10, 100)]
+
+    def test_gen_product_empty(self):
+        """Test gen_product with no arguments."""
+        g = gen_product()
+        result = list(g)
+        assert result == [()]
+
+    def test_gen_product_types_preserved(self):
+        """Test that gen_product preserves type information."""
+        g = gen_product(Gen(int), Gen(str), Gen(float))
+        assert g.types == (int, str, float)
+
+
+class TestGenRepr:
+    """Test Gen string representation."""
+
+    def test_repr_single_type(self):
+        """Test repr with single type."""
+        g = Gen(int)
+        assert repr(g) == "Gen(int)"
+
+    def test_repr_multiple_types(self):
+        """Test repr with composed types."""
+        g = Gen(int) * Gen(str) * Gen(float)
+        assert repr(g) == "Gen(int, str, float)"
+
+    def test_repr_factory(self):
+        """Test repr with factory function."""
+        g = Gen(lambda: iter([1, 2, 3]))
+        assert repr(g) == "Gen(<factory>)"

--- a/tests/test_python_parser.py
+++ b/tests/test_python_parser.py
@@ -247,3 +247,75 @@ def test_unsupported_node_type():
     func_def = tree.body[0]
     with pytest.raises(NotImplementedError, match="Unsupported node type"):
         parse_function_def_to_sentence_group(func_def)
+
+
+# Tests for composable Gen syntax
+@pytest.mark.parametrize(
+    "text,expr",
+    [
+        # Single Gen(Type)
+        (
+            "all(Person(name=x) for x in Gen(Name))",
+            Forall([X], PERSON_TERM),
+        ),
+        # Two Gen types with *
+        (
+            "all(Agent(name=x, age=y) for x, y in Gen(Name) * Gen(int) if Person(name=x, age=y))",
+            Forall([X, Y], Implies(PERSON_TERM2, AGENT_TERM2)),
+        ),
+        # Three Gen types chained
+        (
+            "all(P(x, y, z) for x, y, z in Gen(str) * Gen(int) * Gen(float))",
+            Forall(
+                [Variable("x", "str"), Variable("y", "int"), Variable("z", "float")],
+                Term("P", Variable("x"), Variable("y"), Variable("z")),
+            ),
+        ),
+        # Exists with composable Gen
+        (
+            "any(Person(name=x) for x in Gen(Name))",
+            Exists([X], PERSON_TERM),
+        ),
+    ],
+)
+def test_parse_composable_gen(text, expr):
+    """Test parsing of composable Gen(T) * Gen(U) syntax."""
+    tree = ast.parse(text)
+    func_def = tree.body[0]
+    print(ast.dump(func_def, indent=2))
+    sentence = parse_sentence(func_def)
+    print(f"Parsed: {sentence}")
+    print(f"Expected: {expr}")
+    assert isinstance(sentence, type(expr))
+    assert sentence == expr
+
+
+composable_gen_axiom = """
+def transitivity_axiom() -> bool:
+    return all(
+        AncestorOf(ancestor=x, descendant=y)
+        for x, y, z in Gen(TreeNodeType) * Gen(TreeNodeType) * Gen(TreeNodeType)
+        if AncestorOf(ancestor=x, descendant=z) and AncestorOf(ancestor=z, descendant=y)
+    )
+"""
+
+
+def test_parse_composable_gen_axiom():
+    """Test parsing a full axiom using composable Gen syntax."""
+    tree = ast.parse(composable_gen_axiom)
+    func_def = tree.body[0]
+    sentence_group = parse_function_def_to_sentence_group(func_def)
+
+    assert sentence_group.name == "transitivity_axiom"
+    qs = sentence_group.sentences[0]
+    assert isinstance(qs, Forall)
+    assert qs.quantifier == "all"
+    assert len(qs.variables) == 3
+    assert qs.variables[0].name == "x"
+    assert qs.variables[0].domain == "TreeNodeType"
+    assert qs.variables[1].name == "y"
+    assert qs.variables[1].domain == "TreeNodeType"
+    assert qs.variables[2].name == "z"
+    assert qs.variables[2].domain == "TreeNodeType"
+    sentence = qs.sentence
+    assert isinstance(sentence, Implies)


### PR DESCRIPTION
## Summary

This PR introduces a new composable `Gen` class that enables type-safe, composable generators for logical specifications. The class supports operator-based composition (`*` for cartesian product, `+` for interleaving) while maintaining type information for AST parsing.

## Key Changes

- **New `Gen` class**: A generic, composable generator that can be initialized with either a type (for logical specifications) or a callable factory (for runtime execution)
  - Supports `*` operator for cartesian product composition with automatic tuple flattening
  - Supports `+` operator for interleaving generators
  - Provides transformation methods: `map()`, `filter()`, `take()`
  - Maintains type information via `types` property for AST parser integration

- **Helper functions**: Added convenience functions for common generator patterns
  - `gen_range(start, end)`: Generate integers in a range
  - `gen_list(items)`: Cycle through a list infinitely
  - `gen_const(value)`: Generate the same value infinitely
  - `gen_product(*gens)`: Combine multiple generators into a cartesian product

- **Parser support**: Extended the Python AST parser to recognize and handle composable Gen syntax
  - Updated `parse_generator_node()` to detect `Gen(T) * Gen(T)` patterns
  - Added `parse_composable_gen()` function to extract type information from chained multiplication operations
  - Maintains backward compatibility with legacy `gen1/gen2/gen3` functions

- **Documentation**: Updated module docstring with examples of composable Gen usage in axiom definitions

- **Exports**: Added new classes and functions to `__init__.py` public API

- **Tests**: Comprehensive test suite covering:
  - Basic Gen creation and iteration
  - Operator composition (`*` and `+`)
  - Transformation methods
  - Helper functions
  - String representation
  - AST parsing of composable Gen syntax in axioms

## Implementation Details

The `Gen` class uses a factory pattern internally to support both specification (type-based) and runtime (callable-based) modes. When composed with `*`, tuples are automatically flattened so that `Gen(A) * Gen(B) * Gen(C)` yields `(a, b, c)` rather than nested tuples. Type information is preserved through composition for proper AST parsing of logical specifications.

https://claude.ai/code/session_01UDCgymaxoXGZE6QuM9NTeg