### PR TITLE
[codex] Remove unused mypyc runtime import

### DIFF
--- a/src/typedlogic/compiler.py
+++ b/src/typedlogic/compiler.py
@@ -1,13 +1,12 @@
 """
 Framework for compiling a theory to an external format (e.g., FOL, CL, TPTP, Prolog, etc.)
 """
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import ClassVar, Optional, Type, Union, TextIO, Iterable, List
-
-from mypyc.ir.ops import SetAttr
 
 from typedlogic import Sentence, Theory
 from typedlogic.parser import Parser
@@ -15,12 +14,15 @@ from typedlogic.parser import Parser
 
 def compile_sentences(sentences: Iterable[Sentence], syntax="fol") -> List[str]:
     from typedlogic.registry import get_compiler
+
     compiler = get_compiler(syntax)
     return [compiler.compile_sentence(s) for s in sentences]
+
 
 def write_sentences(sentences: Iterable[Sentence], syntax="fol"):
     for s in compile_sentences(sentences, syntax=syntax):
         print(s)
+
 
 class ModelSyntax(str, Enum):
     """

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -22,14 +22,14 @@ import importlib.abc
 import sys
 
 
-class BlockMypyc(importlib.abc.MetaPathFinder):
+class BlockOptionalMypy(importlib.abc.MetaPathFinder):
     def find_spec(self, fullname, path=None, target=None):
-        if fullname == "mypyc" or fullname.startswith("mypyc."):
+        if fullname in {"mypy", "mypyc"} or fullname.startswith(("mypy.", "mypyc.")):
             raise ModuleNotFoundError(fullname)
         return None
 
 
-sys.meta_path.insert(0, BlockMypyc())
+sys.meta_path.insert(0, BlockOptionalMypy())
 import typedlogic.compiler
 """
     env = os.environ.copy()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,6 +1,37 @@
 import os
+import subprocess
+import sys
+from pathlib import Path
 
 
 def test_env():
     path = os.getenv("PATH")
     print(path)
+
+
+def test_compiler_import_does_not_require_mypyc():
+    """
+    The compiler module must import without the optional mypy/mypyc runtime.
+
+    This guards against accidentally adding development-only imports to the
+    runtime path.
+    """
+
+    script = """
+import importlib.abc
+import sys
+
+
+class BlockMypyc(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "mypyc" or fullname.startswith("mypyc."):
+            raise ModuleNotFoundError(fullname)
+        return None
+
+
+sys.meta_path.insert(0, BlockMypyc())
+import typedlogic.compiler
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    subprocess.run([sys.executable, "-c", script], check=True, env=env)


### PR DESCRIPTION
## Summary

Fixes #10 by removing the unused `mypyc.ir.ops.SetAttr` import from `typedlogic.compiler`, so compiler imports no longer require the development-only `mypy`/`mypyc` package at runtime.

Adds a regression test that blocks `mypyc` imports in a subprocess and verifies `typedlogic.compiler` still imports successfully.

## Validation

- `poetry run pytest tests/test_imports.py`
- `PYTHONPATH=src poetry run python - <<'PY' ... import typedlogic.compiler ... PY`
- `git diff --check`