### PR TITLE
[codex] Improve ProbLog evidence diagnostics

### DIFF
--- a/src/typedlogic/integrations/solvers/problog/problog_solver.py
+++ b/src/typedlogic/integrations/solvers/problog/problog_solver.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass, field
 from typing import Any, ClassVar, Dict, Iterator, Optional
 
 from problog import get_evaluatable
+from problog.errors import InconsistentEvidenceError
 from problog.program import PrologString
 
 from typedlogic.datamodel import NotInProfileError, Sentence, Term
@@ -20,8 +21,20 @@ from typedlogic.solver import Solution, Solver
 logger = logging.getLogger(__name__)
 
 DEFAULT_PROBLOG_ARGS = {
-    'propagate_evidence': False,
+    "propagate_evidence": False,
 }
+
+
+class UnsatisfiableEvidenceError(NotInProfileError):
+    """
+    Raised when ProbLog evidence is inconsistent with the program.
+    """
+
+
+class AmbiguousModelError(NotInProfileError):
+    """
+    Raised when a single-model API sees more than one probabilistic model.
+    """
 
 
 @dataclass
@@ -67,7 +80,13 @@ class ProbLogSolver(Solver):
             for k, v in self.problog_args.items():
                 if k not in kwargs:
                     kwargs[k] = v
-        result = ev.create_from(p, **kwargs).evaluate()
+        try:
+            result = ev.create_from(p, **kwargs).evaluate()
+        except InconsistentEvidenceError as e:
+            raise UnsatisfiableEvidenceError(
+                "ProbLog evidence is inconsistent; no probabilistic model can satisfy the asserted evidence. "
+                f"ProbLog reported: {e}"
+            ) from e
         m = ProbabilisticModel()
         for term, prob in result.items():
             plt_term = compiler.decompile_term(term)
@@ -82,13 +101,21 @@ class ProbLogSolver(Solver):
     def model(self) -> ProbabilisticModel:
         models = list(self.models())
         if len(models) == 0:
-            raise NotInProfileError("No models found")
+            raise UnsatisfiableEvidenceError(
+                "ProbLog produced no models; the evidence may be unsatisfiable for this probabilistic theory."
+            )
         if len(models) > 1:
-            raise NotInProfileError("Multiple models found")
+            raise AmbiguousModelError(
+                "ProbLog produced multiple models; ProbLogSolver.model() expects exactly one model. "
+                "Use ProbLogSolver.models() to inspect all models."
+            )
         return models[0]
 
     def check(self) -> Solution:
-        models = list(self.models())
+        try:
+            models = list(self.models())
+        except UnsatisfiableEvidenceError:
+            return Solution(satisfiable=False)
         sat = len(models) > 0
         return Solution(satisfiable=sat)
 

--- a/tests/test_integrations/problog/test_problog.py
+++ b/tests/test_integrations/problog/test_problog.py
@@ -8,10 +8,10 @@ from problog import get_evaluatable
 from problog.program import PrologString
 from tests import OUTPUT_DIR, tree_edges
 from typedlogic import Theory
-from typedlogic.datamodel import Forall, Variable, Implies, Term
+from typedlogic.datamodel import Forall, Variable, Implies, PredicateDefinition, Term
 from typedlogic.extensions.probabilistic import Evidence, ProbabilisticModel, Probability, That
 from typedlogic.integrations.solvers.problog.problog_compiler import ProbLogCompiler
-from typedlogic.integrations.solvers.problog.problog_solver import ProbLogSolver
+from typedlogic.integrations.solvers.problog.problog_solver import ProbLogSolver, UnsatisfiableEvidenceError
 from typedlogic.parsers.pyparser.introspection import translate_module_to_theory
 
 from tests.theorems.probabilistic import coins, coins2, smokers
@@ -152,6 +152,19 @@ def test_solver(theory_module, facts, evidences, expected):
     #    print(pr, "::", term, type(term), model.term_probabilities[term])
     for term, pr in expected:
         assert round(model.term_probabilities[term.to_model_object()], 3) == pr
+
+
+def test_solver_model_reports_unsatisfiable_evidence():
+    solver = ProbLogSolver()
+    solver.add_predicate_definition(PredicateDefinition(predicate="Foo", arguments={}))
+    solver.add_probabilistic_fact(Term("Foo"), 0.5)
+    solver.add_evidence(Term("Foo"), True)
+    solver.add_evidence(Term("Foo"), False)
+
+    assert solver.check().satisfiable is False
+    with pytest.raises(UnsatisfiableEvidenceError, match="evidence is inconsistent"):
+        solver.model()
+
 
 @pytest.mark.parametrize(
     "facts,disease_priors,phenotype_priors,d2p,d2g,evidences",


### PR DESCRIPTION
## Summary
- add distinct ProbLog errors for unsatisfiable evidence and ambiguous model results
- translate ProbLog inconsistent evidence into an unsatisfiable solver check result
- add a regression test for contradictory evidence through model() and check()

Fixes #12

## Validation
- poetry run pytest tests/test_integrations/problog/test_problog.py::test_solver_model_reports_unsatisfiable_evidence
- poetry run pytest tests/test_integrations/problog/test_problog.py
- git diff --check