### PR TITLE
[codex] Add collider bias probabilistic tutorial

### DIFF
--- a/docs/tutorial/03-probabilistic-logic.ipynb
+++ b/docs/tutorial/03-probabilistic-logic.ipynb
@@ -473,6 +473,112 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
+    "## Conditioning on a collider\n",
+    "\n",
+    "A collider is a fact that can be caused by two independent facts. Conditioning on the collider makes the causes depend on each other, even though they started independent. In statistics this is Berkson's paradox; in probabilistic logic it appears when two rules share the same head.\n",
+    "\n",
+    "Here a person dates if they are hot, and also dates if they are smart:\n"
+   ],
+   "id": "b11c0llider_intro"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "from typedlogic import Forall, PredicateDefinition, Term, Variable\n",
+    "from typedlogic.integrations.solvers.problog import ProbLogSolver\n",
+    "\n",
+    "\n",
+    "def fresh_collider_solver():\n",
+    "    solver = ProbLogSolver()\n",
+    "    for predicate in (\"Hot\", \"Smart\", \"Dates\"):\n",
+    "        solver.add_predicate_definition(PredicateDefinition(predicate=predicate, arguments={\"person\": \"str\"}))\n",
+    "\n",
+    "    person = Variable(\"person\")\n",
+    "    solver.add_sentence(Forall([person], Term(\"Hot\", person) >> Term(\"Dates\", person)))\n",
+    "    solver.add_sentence(Forall([person], Term(\"Smart\", person) >> Term(\"Dates\", person)))\n",
+    "    solver.add_probabilistic_fact(Term(\"Hot\", \"p\"), 0.5)\n",
+    "    solver.add_probabilistic_fact(Term(\"Smart\", \"p\"), 0.5)\n",
+    "    return solver\n"
+   ],
+   "id": "b11c0llider_setup",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "Now we can query the same probability under four evidence sets:\n",
+    "\n",
+    "| Conditioning | P(Hot) | Interpretation |\n",
+    "| --- | ---: | --- |\n",
+    "| none | 0.500 | baseline prior |\n",
+    "| `!Smart` | 0.500 | the two causes are marginally independent |\n",
+    "| `Dates` | 0.667 | conditioning on the collider raises `P(Hot)` |\n",
+    "| `Dates, !Smart` | 1.000 | once `Smart` is ruled out, `Hot` is the remaining cause of `Dates` |\n"
+   ],
+   "id": "b11c0llider_table"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "def hot_probability(*evidence):\n",
+    "    solver = fresh_collider_solver()\n",
+    "    for term, truth_value in evidence:\n",
+    "        solver.add_evidence(term, truth_value)\n",
+    "    return solver.model().term_probabilities[Term(\"Hot\", \"p\")]\n",
+    "\n",
+    "\n",
+    "collider_rows = [\n",
+    "    (\"none\", hot_probability(), \"baseline prior\"),\n",
+    "    (\"!Smart\", hot_probability((Term(\"Smart\", \"p\"), False)), \"independent cause stays independent\"),\n",
+    "    (\"Dates\", hot_probability((Term(\"Dates\", \"p\"), True)), \"conditioning on the collider raises P(Hot)\"),\n",
+    "    (\n",
+    "        \"Dates, !Smart\",\n",
+    "        hot_probability((Term(\"Dates\", \"p\"), True), (Term(\"Smart\", \"p\"), False)),\n",
+    "        \"Dates needs Hot once Smart is ruled out\",\n",
+    "    ),\n",
+    "]\n",
+    "\n",
+    "for condition, probability, interpretation in collider_rows:\n",
+    "    print(f\"{condition:14} P(Hot)={probability:.3f}  {interpretation}\")\n"
+   ],
+   "id": "b11c0llider_query",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "The contrast between `!Smart` and `Dates, !Smart` is the collider effect. Learning `!Smart` alone leaves `P(Hot)` at `0.5`. Once we condition on `Dates`, the same fact removes one possible cause of dating, so the probability mass shifts to `Hot`. The same shape models examples such as hospital-selection bias, where conditioning on hospitalization can make independent diseases look related.\n"
+   ],
+   "id": "b11c0llider_interpretation"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "print(fresh_collider_solver().dump())\n"
+   ],
+   "id": "b11c0llider_dump",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "The generated ProbLog program shows the two clauses sharing `dates(Person)` as the head. That shared head is the collider; evidence on `dates(\"p\")` opens the path between the independent parents.\n"
+   ],
+   "id": "b11c0llider_dump_note"
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
     "## How it works\n",
     "\n",
     "The ProbLog solver works by converting the theorem into a ProbLog program, and then using a ProbLog.\n",

--- a/docs/tutorial/03-probabilistic-logic.ipynb
+++ b/docs/tutorial/03-probabilistic-logic.ipynb
@@ -503,7 +503,7 @@
    ],
    "id": "b11c0llider_setup",
    "outputs": [],
-   "execution_count": 14
+   "execution_count": null
   },
   {
    "metadata": {},
@@ -558,7 +558,7 @@
      ]
     }
    ],
-   "execution_count": 15
+   "execution_count": null
   },
   {
    "metadata": {},
@@ -590,7 +590,7 @@
      ]
     }
    ],
-   "execution_count": 16
+   "execution_count": null
   },
   {
    "metadata": {},

--- a/docs/tutorial/03-probabilistic-logic.ipynb
+++ b/docs/tutorial/03-probabilistic-logic.ipynb
@@ -503,7 +503,7 @@
    ],
    "id": "b11c0llider_setup",
    "outputs": [],
-   "execution_count": null
+   "execution_count": 14
   },
   {
    "metadata": {},
@@ -546,8 +546,19 @@
     "    print(f\"{condition:14} P(Hot)={probability:.3f}  {interpretation}\")\n"
    ],
    "id": "b11c0llider_query",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "none           P(Hot)=0.500  baseline prior\n",
+      "!Smart         P(Hot)=0.500  independent cause stays independent\n",
+      "Dates          P(Hot)=0.667  conditioning on the collider raises P(Hot)\n",
+      "Dates, !Smart  P(Hot)=1.000  Dates needs Hot once Smart is ruled out\n"
+     ]
+    }
+   ],
+   "execution_count": 15
   },
   {
    "metadata": {},
@@ -564,8 +575,22 @@
     "print(fresh_collider_solver().dump())\n"
    ],
    "id": "b11c0llider_dump",
-   "outputs": [],
-   "execution_count": null
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dates(Person) :- hot(Person).\n",
+      "dates(Person) :- smart(Person).\n",
+      "0.5::hot(\"p\").\n",
+      "0.5::smart(\"p\").\n",
+      "query(hot(Person)).\n",
+      "query(smart(Person)).\n",
+      "query(dates(Person)).\n"
+     ]
+    }
+   ],
+   "execution_count": 16
   },
   {
    "metadata": {},


### PR DESCRIPTION
## Summary
- add a collider-bias / Berkson's paradox section to the probabilistic logic tutorial notebook
- include a reusable ProbLogSolver setup with two independent causes sharing a `Dates` head
- document and validate the four evidence cases showing the collider effect

Fixes #11

## Validation
- poetry run python -m json.tool docs/tutorial/03-probabilistic-logic.ipynb >/dev/null
- executed the inserted notebook code cells and asserted the expected probabilities
- nbformat.validate on docs/tutorial/03-probabilistic-logic.ipynb
- git diff --check