### PR TITLE
[codex] Add ergonomic TLog parser

### DIFF
--- a/docs/conversion/compilers/tlog.md
+++ b/docs/conversion/compilers/tlog.md
@@ -1,0 +1,24 @@
+# TLog Compiler
+
+The TLog compiler writes a TypedLogic theory back to the ergonomic TLog syntax.
+It is available as the generic `tlog` output format.
+
+::: typedlogic.compilers.tlog_compiler.TLogCompiler
+
+## CLI
+
+Convert any parser-supported input to TLog:
+
+```bash
+typedlogic convert docs/examples/tlog/ancestor.tlog -t tlog
+```
+
+Because this is a normal compiler target, it also works with `dump`:
+
+```bash
+typedlogic dump docs/examples/tlog/ancestor.tlog -t tlog
+```
+
+This is useful for normalizing authored TLog, extracting the logical content of
+literate Markdown, or moving through an intermediate format and back to a compact
+text representation.

--- a/docs/conversion/parsers/index.md
+++ b/docs/conversion/parsers/index.md
@@ -10,6 +10,7 @@ TypedLogic supports parsing from multiple input formats to create logical theori
 
 - **[Python Parser](python.md)** - Parse Python modules with TypedLogic decorators
 - **[YAML Parser](yaml.md)** - Parse YAML files containing logical specifications
+- **[TLog Parser](tlog.md)** - Parse compact `.tlog` files and literate `.tlog.md` Markdown files
 
 ### Data Parsers  
 

--- a/docs/conversion/parsers/tlog.md
+++ b/docs/conversion/parsers/tlog.md
@@ -1,0 +1,152 @@
+# TLog Parser
+
+TLog is a compact text syntax for authoring TypedLogic theories without using
+Python. It is still just another TypedLogic parser: the same `convert`, `dump`,
+and `solve` commands work with it.
+
+::: typedlogic.parsers.tlog_parser.TLogParser
+
+::: typedlogic.parsers.tlog_parser.TLogMarkdownParser
+
+## Syntax
+
+```tlog
+type PersonID: str.
+
+pred parent(parent: PersonID, child: PersonID).
+pred ancestor(ancestor: PersonID, descendant: PersonID).
+
+parent("Alice", "Bob").
+parent("Bob", "Charlie").
+
+/// Direct parent links are ancestor links.
+ancestor(x, y) :- parent(x, y).
+
+/// Ancestor links are transitive.
+ancestor(x, z) :- ancestor(x, y), ancestor(y, z).
+```
+
+Types are optional. Untyped targets can ignore them; typed targets such as
+Souffle can use them.
+
+Predicate and variable names are case-preserving. Variables are not inferred from
+capitalization. In a rule or explicit quantifier, bare names are variables:
+
+```tlog
+ancestor(x, Y) :- parent(x, z), ancestor(z, Y).
+```
+
+In facts, bare names are constants:
+
+```tlog
+parent(Alice, Bob).
+```
+
+Use quoted strings when a constant appears in a rule body or head:
+
+```tlog
+favorite_child(x) :- parent("Alice", x).
+```
+
+## Quantifiers
+
+Explicit universal and existential quantifiers are available:
+
+```tlog
+all x, y | parent(x, y) -> ancestor(x, y).
+exists witness | observed(witness).
+```
+
+The classic symbols are accepted aliases:
+
+```tlog
+∀ x, y | parent(x, y) -> ancestor(x, y).
+∃ witness | observed(witness).
+```
+
+If you need to disambiguate a variable without an explicit quantifier, use `?`:
+
+```tlog
+likes(?person, "tea") -> happy(?person).
+```
+
+## HiLog-Style Predicate Variables
+
+Use `@name(...)` to put a variable in predicate position:
+
+```tlog
+all slot, i, v | @slot(i, v) -> has_slot_value(i, slot).
+```
+
+This is useful for schema or macro-expansion layers. Backends that require fixed
+first-order predicate names may reject such sentences until they are expanded.
+
+## Literate Markdown
+
+Markdown files ending in `.tlog.md` are parsed by `TLogMarkdownParser`. Prose is
+ignored and fenced `tlog`, `typedlogic`, or `logic` blocks are parsed in order:
+
+````markdown
+# Family rules
+
+Only this fenced block is parsed:
+
+```tlog
+pred parent(parent: str, child: str).
+pred ancestor(ancestor: str, descendant: str).
+ancestor(x, y) :- parent(x, y).
+```
+````
+
+## CLI
+
+The CLI auto-detects `.tlog` and `.tlog.md` files. Use `-f tlog` or
+`-f tlogmarkdown` only when the suffix does not identify the format.
+
+Convert TLog to another format:
+
+```bash
+typedlogic convert docs/examples/tlog/ancestor.tlog -t prolog
+typedlogic convert docs/examples/tlog/ancestor.tlog -t yaml
+typedlogic convert docs/examples/tlog/ancestor.tlog -t souffle
+```
+
+Convert any parser-supported input to TLog:
+
+```bash
+typedlogic convert docs/examples/tlog/ancestor.tlog -t tlog
+```
+
+Use `dump` when combining multiple input files or when you want pure
+auto-detection:
+
+```bash
+typedlogic dump docs/examples/tlog/literate-rules.tlog.md -t prolog
+```
+
+Run inference with any installed solver:
+
+```bash
+typedlogic solve docs/examples/tlog/ancestor.tlog --solver clingo
+```
+
+Show only selected materialized predicates:
+
+```bash
+typedlogic solve docs/examples/tlog/ancestor.tlog \
+  --solver clingo \
+  --show ancestor \
+  --max-models 1
+```
+
+Show multiple answer sets:
+
+```bash
+typedlogic solve docs/examples/tlog/worlds.tlog \
+  --solver clingo \
+  --show selected \
+  --max-models 2
+```
+
+The `--show` and `--max-models` options are generic `solve` options, not
+TLog-specific commands.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -5,6 +5,8 @@ This page provides various examples to illustrate the usage of TypedLogic in dif
 ## Gallery Tutorials
 
 - [Synthetic biology design checks](examples/synbio-design-checks.ipynb): assembly structure, GO-driven pathway feasibility, and GO-CAM curation consistency in one reusable theory.
+- [TLog CLI examples](examples/tlog-cli.md): author `.tlog` and literate `.tlog.md` files, convert them, run Clingo, filter materialized predicates, and inspect multiple worlds.
+- [TLog notebook](examples/tlog-cli.ipynb): notebook form of the same CLI-oriented workflow.
 
 ## Basic Family Relationships
 

--- a/docs/examples/tlog-cli.ipynb
+++ b/docs/examples/tlog-cli.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# TLog CLI Workflow\n",
+    "\n",
+    "This notebook shows the command-line workflow for TLog. TLog is just another parser/compiler syntax: the generic `typedlogic convert`, `typedlogic dump`, and `typedlogic solve` commands do the work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "workspace = Path(\"tlog-demo\")\n",
+    "workspace.mkdir(exist_ok=True)\n",
+    "ancestor_tlog = workspace / \"ancestor.tlog\"\n",
+    "ancestor_tlog.write_text(\n",
+    "    \"\"\"\n",
+    "type PersonID: str.\n",
+    "\n",
+    "pred parent(parent: PersonID, child: PersonID).\n",
+    "pred ancestor(ancestor: PersonID, descendant: PersonID).\n",
+    "\n",
+    "parent(\"Alice\", \"Bob\").\n",
+    "parent(\"Bob\", \"Charlie\").\n",
+    "\n",
+    "/// Direct parent links are ancestor links.\n",
+    "ancestor(x, y) :- parent(x, y).\n",
+    "\n",
+    "/// Ancestor links are transitive.\n",
+    "ancestor(x, z) :- ancestor(x, y), ancestor(y, z).\n",
+    "    \"\"\".strip()\n",
+    "    + \"\\n\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "ancestor_tlog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert TLog To Other Formats\n",
+    "\n",
+    "The input format is inferred from `.tlog`; the output format is selected with `-t`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!typedlogic convert tlog-demo/ancestor.tlog -t prolog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!typedlogic convert tlog-demo/ancestor.tlog -t yaml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Convert Back To TLog\n",
+    "\n",
+    "`tlog` is also a compiler target."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!typedlogic convert tlog-demo/ancestor.tlog -t tlog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run Inference With Clingo\n",
+    "\n",
+    "`--show` filters materialized ground terms by predicate. `--max-models` limits model output."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!typedlogic solve tlog-demo/ancestor.tlog --solver clingo --show ancestor --max-models 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Literate Markdown\n",
+    "\n",
+    "A `.tlog.md` file can mix prose and fenced TLog blocks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "literate = workspace / \"literate-rules.tlog.md\"\n",
+    "literate.write_text(\n",
+    "    \"\"\"\n",
+    "# Family Rules\n",
+    "\n",
+    "Only fenced `tlog` blocks are parsed.\n",
+    "\n",
+    "```tlog\n",
+    "pred parent(parent: str, child: str).\n",
+    "pred ancestor(ancestor: str, descendant: str).\n",
+    "parent(\"Alice\", \"Bob\").\n",
+    "∀ x, y | parent(x, y) -> ancestor(x, y).\n",
+    "```\n",
+    "    \"\"\".strip()\n",
+    "    + \"\\n\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "literate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!typedlogic dump tlog-demo/literate-rules.tlog.md -t prolog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multiple Worlds\n",
+    "\n",
+    "When the selected solver supports multiple models, the same generic `solve` command can show them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "worlds_tlog = workspace / \"worlds.tlog\"\n",
+    "worlds_tlog.write_text(\n",
+    "    \"\"\"\n",
+    "pred selected(option: str).\n",
+    "pred hidden(option: str).\n",
+    "\n",
+    "selected(\"tea\") | selected(\"coffee\").\n",
+    "hidden(\"noise\").\n",
+    "    \"\"\".strip()\n",
+    "    + \"\\n\",\n",
+    "    encoding=\"utf-8\",\n",
+    ")\n",
+    "worlds_tlog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!typedlogic solve tlog-demo/worlds.tlog --solver clingo --show selected --max-models 2"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/tlog-cli.md
+++ b/docs/examples/tlog-cli.md
@@ -1,0 +1,124 @@
+# TLog CLI Examples
+
+TLog is a parser and compiler format, not a separate CLI mode. Use the existing
+generic commands:
+
+- `convert` for one input theory to one output format
+- `dump` for combining and exporting inputs
+- `solve` for satisfiability, materialization, and answer-set enumeration
+
+## Convert TLog To Other Formats
+
+```bash
+typedlogic convert docs/examples/tlog/ancestor.tlog -t prolog
+```
+
+Example output:
+
+```prolog
+%% Predicate Definitions
+% parent(parent: PersonID, child: PersonID)
+% ancestor(ancestor: PersonID, descendant: PersonID)
+
+parent('Alice', 'Bob').
+parent('Bob', 'Charlie').
+ancestor(X, Y) :- parent(X, Y).
+ancestor(X, Z) :- ancestor(X, Y), ancestor(Y, Z).
+```
+
+Other compiler targets work the same way:
+
+```bash
+typedlogic convert docs/examples/tlog/ancestor.tlog -t yaml
+typedlogic convert docs/examples/tlog/ancestor.tlog -t fol
+typedlogic convert docs/examples/tlog/ancestor.tlog -t souffle
+```
+
+## Convert To TLog
+
+Use `-t tlog` with any parser-supported input:
+
+```bash
+typedlogic convert docs/examples/tlog/ancestor.tlog -t tlog
+```
+
+Example output:
+
+```tlog
+type PersonID: str.
+
+pred parent(parent: PersonID, child: PersonID).
+pred ancestor(ancestor: PersonID, descendant: PersonID).
+
+parent('Alice', 'Bob').
+parent('Bob', 'Charlie').
+/// Direct parent links are ancestor links.
+all x, y | ancestor(x, y) :- parent(x, y).
+/// Ancestor links are transitive.
+all x, y, z | ancestor(x, z) :- (ancestor(x, y) & ancestor(y, z)).
+```
+
+## Literate Markdown
+
+Files ending in `.tlog.md` are parsed as Markdown wrappers around fenced TLog
+blocks:
+
+```bash
+typedlogic dump docs/examples/tlog/literate-rules.tlog.md -t prolog
+```
+
+The prose is ignored. Fenced `tlog`, `typedlogic`, or `logic` blocks are parsed
+in order.
+
+## Run Inference With Clingo
+
+```bash
+typedlogic solve docs/examples/tlog/ancestor.tlog \
+  --solver clingo \
+  --show ancestor \
+  --max-models 1
+```
+
+Example output:
+
+```text
+Satisfiable: True
+
+=== Model 1 ===
+ancestor(Alice, Bob)
+ancestor(Bob, Charlie)
+ancestor(Alice, Charlie)
+
+Total models shown: 1
+```
+
+`--show ancestor` filters materialized output to selected predicates. It is a
+generic `solve` option and works for other syntaxes too.
+
+## Show Multiple Worlds
+
+Answer-set solvers such as Clingo can produce multiple models:
+
+```bash
+typedlogic solve docs/examples/tlog/worlds.tlog \
+  --solver clingo \
+  --show selected \
+  --max-models 2
+```
+
+Example output:
+
+```text
+Satisfiable: True
+
+=== Model 1 ===
+selected(coffee)
+
+=== Model 2 ===
+selected(tea)
+
+Total models shown: 2
+```
+
+The input syntax is still just TLog; the multiple-world behavior comes from the
+chosen solver.

--- a/docs/examples/tlog/ancestor.tlog
+++ b/docs/examples/tlog/ancestor.tlog
@@ -1,0 +1,13 @@
+type PersonID: str.
+
+pred parent(parent: PersonID, child: PersonID).
+pred ancestor(ancestor: PersonID, descendant: PersonID).
+
+parent("Alice", "Bob").
+parent("Bob", "Charlie").
+
+/// Direct parent links are ancestor links.
+ancestor(x, y) :- parent(x, y).
+
+/// Ancestor links are transitive.
+ancestor(x, z) :- ancestor(x, y), ancestor(y, z).

--- a/docs/examples/tlog/literate-rules.tlog.md
+++ b/docs/examples/tlog/literate-rules.tlog.md
@@ -1,0 +1,24 @@
+# Literate TLog Example
+
+The prose in this file is documentation for readers. The `tlog` blocks are the
+logical content parsed by `TLogMarkdownParser`.
+
+```tlog
+type PersonID: str.
+
+pred parent(parent: PersonID, child: PersonID).
+pred ancestor(ancestor: PersonID, descendant: PersonID).
+```
+
+Facts and rules can be introduced where they are explained.
+
+```tlog
+parent("Alice", "Bob").
+parent("Bob", "Charlie").
+
+/// Direct parent links are ancestor links.
+∀ x, y | parent(x, y) -> ancestor(x, y).
+
+/// Ancestor links are transitive.
+ancestor(x, z) :- ancestor(x, y), ancestor(y, z).
+```

--- a/docs/examples/tlog/worlds.tlog
+++ b/docs/examples/tlog/worlds.tlog
@@ -1,0 +1,8 @@
+pred selected(option: str).
+pred explanation(option: str).
+pred hidden(option: str).
+
+selected("tea") | selected("coffee").
+
+explanation(option) :- selected(option).
+hidden("noise").

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,8 @@ nav:
   - Gallery:
       - Examples: examples.md
       - Synthetic biology design checks: examples/synbio-design-checks.ipynb
+      - TLog CLI workflow: examples/tlog-cli.md
+      - TLog CLI notebook: examples/tlog-cli.ipynb
   - Concepts:
       - Core concepts: concepts/index.md
       - Data Model: concepts/datamodel.md
@@ -84,6 +86,7 @@ nav:
   - Compilers:
       - Compiler overview: conversion/compilers/index.md
       - YAML: conversion/compilers/yaml.md
+      - TLog: conversion/compilers/tlog.md
       - Prolog: conversion/compilers/prolog.md
       - ProbLog: conversion/compilers/problog.md
       - TPTP: conversion/compilers/tptp.md
@@ -92,6 +95,7 @@ nav:
   - Parsers:
       - Parser overview: conversion/parsers/index.md
       - Python: conversion/parsers/python.md
+      - TLog: conversion/parsers/tlog.md
       - YAML: conversion/parsers/yaml.md
       - DataFrame: conversion/parsers/dataframe.md
       - Catalog: conversion/parsers/catalog.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 requires-python = ">=3.10,<4.0"
 dependencies = [
     "importlib-metadata>=8.2.0",
+    "lark>=1.2.0",
     "typer>=0.12.5",
 ]
 

--- a/src/typedlogic/cli.py
+++ b/src/typedlogic/cli.py
@@ -27,12 +27,19 @@ import click
 import typer
 from typer.main import get_command
 
-from typedlogic.registry import get_compiler, get_parser, get_solver, all_parser_classes, all_compiler_classes, all_solver_classes
+from typedlogic.registry import (
+    all_compiler_classes,
+    all_parser_classes,
+    all_solver_classes,
+    get_compiler,
+    get_parser,
+    get_solver,
+)
 
 app = typer.Typer()
 
 input_format_option = typer.Option(
-    "python", "--input-format", "-f", help="Input format. Currently supported: python, yaml, owlpy"
+    None, "--input-format", "-f", help="Input format; inferred from file suffix if omitted"
 )
 output_format_option = typer.Option(None, "--output-format", "-t", help="Output format")
 
@@ -74,7 +81,7 @@ def list_solvers():
 @app.command()
 def convert(
     theory_files: List[Path] = typer.Argument(..., exists=True, dir_okay=False, readable=True),
-    input_format: str = input_format_option,
+    input_format: Optional[str] = input_format_option,
     output_format: str = output_format_option,
     output_file: Optional[Path] = output_file_option,
     validate_types: bool = typer.Option(
@@ -96,7 +103,7 @@ def convert(
     ```
 
     """
-    parser = get_parser(input_format)
+    parser = get_parser(input_format or _guess_format(theory_files[0]))
     if validate_types:
         for p in theory_files:
             errs = parser.validate(p)
@@ -126,7 +133,9 @@ def _guess_format(data_file: Path) -> str:
     # Check for catalog files first
     if data_file.name.endswith('.catalog.yaml') or data_file.name.endswith('.catalog.yml'):
         return "catalog"
-    
+    if data_file.name.endswith(".tlog.md"):
+        return "tlogmarkdown"
+
     suffix = data_file.suffix[1:]
     if suffix == "py":
         return "python"
@@ -138,16 +147,16 @@ def _guess_format(data_file: Path) -> str:
 def _combine_input_files(input_files: List[Path], validate_types: bool = True):
     """
     Combine multiple input files into a single theory.
-    
+
     Args:
     ----
         input_files: List of file paths to combine
         validate_types: Whether to validate Python files with mypy
-        
+
     Returns:
     -------
         Combined theory object
-        
+
     Raises:
     ------
         ValueError: If validation fails or no valid theories found
@@ -237,22 +246,31 @@ def _combine_input_files(input_files: List[Path], validate_types: bool = True):
 def solve(
     theory_file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True),
     solver: str = typer.Option("souffle", "--solver", "-s", help="Solver to use (z3, souffle, clingo, etc.)"),
-    check_only: bool = typer.Option(False, "--check-only", "-c", help="Check satisfiability only, do not enumerate models"),
+    check_only: bool = typer.Option(
+        False, "--check-only", "-c", help="Check satisfiability only, do not enumerate models"
+    ),
     validate_types: bool = typer.Option(
         True, "--validate-types/--no-validate-types", help="Use mypy to validate types"
     ),
-    input_format: str = input_format_option,
+    input_format: Optional[str] = input_format_option,
     data_input_format: str = typer.Option(None, "--data-input-format", "-d", help="Format for ground terms"),
     output_format: str = output_format_option,
     output_file: Optional[Path] = output_file_option,
+    show_predicates: Optional[List[str]] = typer.Option(
+        None,
+        "--show",
+        "--predicate",
+        help="Only show materialized ground terms for these predicates. Repeat for multiple predicates.",
+    ),
+    max_models: Optional[int] = typer.Option(None, "--max-models", help="Stop after showing this many models"),
     data_files: Annotated[Optional[List[Path]], typer.Argument()] = None,
 ):
     """
     Solve logical theories with facts using the specified solver.
-    
+
     Accepts a theory file and optional data files containing facts.
     Files can be Python (.py) or YAML (.yaml) format - format is auto-detected.
-    
+
     First checks satisfiability, then enumerates all models if satisfiable.
 
     Examples
@@ -260,26 +278,26 @@ def solve(
     ```bash
     # Solve with theory and facts
     typedlogic solve theory.py facts.yaml --solver z3
-    
+
     # Check satisfiability only
     typedlogic solve theory.py --check-only
-    
+
     # Solve with multiple data files
     typedlogic solve theory.py data1.yaml data2.yaml --solver z3
     ```
 
     """
     # Parse theory file
-    parser = get_parser(input_format or "python")
+    parser = get_parser(input_format or _guess_format(theory_file))
     if validate_types:
         errs = parser.validate(theory_file)
         if errs:
             for err in errs:
                 click.echo(f"Validation error in {theory_file}: {err}")
             raise typer.Exit(1)
-    
+
     combined_theory = parser.parse(theory_file)
-    
+
     # Parse data files and add ground terms
     if data_files:
         if combined_theory.ground_terms is None:
@@ -318,17 +336,22 @@ def solve(
             model_count = 0
             for model in solver_instance.models():
                 result += f"\n=== Model {model_count + 1} ===\n"
-                if model.ground_terms:
-                    for fact in model.ground_terms:
+                facts = model.ground_terms
+                if show_predicates:
+                    facts = [fact for fact in facts if str(fact.predicate) in show_predicates]
+                if facts:
+                    for fact in facts:
                         result += f"{fact}\n"
                 else:
                     result += "(empty model)\n"
                 model_count += 1
+                if max_models is not None and model_count >= max_models:
+                    break
 
             if model_count == 0:
                 result += "No models generated (solver may not support model enumeration).\n"
             else:
-                result += f"\nTotal models found: {model_count}\n"
+                result += f"\nTotal models shown: {model_count}\n"
 
 
     # Output results
@@ -352,10 +375,10 @@ def dump(
 ):
     """
     Parse and combine multiple input files, then export to specified format without solving.
-    
+
     This command is useful for preprocessing, format conversion, and inspecting
     the combined logical theory before solving.
-    
+
     Files can be Python (.py) or YAML (.yaml) format - format is auto-detected.
 
     Examples
@@ -363,10 +386,10 @@ def dump(
     ```bash
     # Combine and export to first-order logic
     typedlogic dump theory.py facts.yaml -t fol -o combined.fol
-    
+
     # Export to YAML format
     typedlogic dump axioms.py data.yaml -t yaml
-    
+
     # Combine multiple files and view as Prolog
     typedlogic dump theory1.py theory2.py facts.yaml -t prolog
     ```

--- a/src/typedlogic/compilers/tlog_compiler.py
+++ b/src/typedlogic/compilers/tlog_compiler.py
@@ -1,0 +1,146 @@
+"""Compiler for TypedLogic's ergonomic text rule syntax."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar, Optional, Union
+
+from typedlogic import And, Exists, Forall, Iff, Implies, NegationAsFailure, Not, Or, Term, Theory
+from typedlogic.compiler import Compiler, ModelSyntax
+from typedlogic.datamodel import PredicateDefinition, Sentence, Variable
+from typedlogic.parsers.tlog_parser import TLogParser
+
+
+@dataclass
+class TLogCompiler(Compiler):
+    """Compile a theory into TLog syntax."""
+
+    default_suffix: ClassVar[str] = "tlog"
+    parser_class: ClassVar[type[TLogParser]] = TLogParser
+
+    def compile(self, theory: Theory, syntax: Optional[Union[str, ModelSyntax]] = None, **kwargs: Any) -> str:
+        """Compile a Theory object into TLog syntax."""
+        lines: list[str] = []
+        for name, base in theory.type_definitions.items():
+            lines.append(f"type {name}: {base}.")
+        if theory.type_definitions and theory.predicate_definitions:
+            lines.append("")
+
+        for predicate_definition in theory.predicate_definitions:
+            lines.append(self._predicate_definition(predicate_definition))
+        if theory.predicate_definitions and (theory.sentence_groups or theory.ground_terms):
+            lines.append("")
+
+        for sentence_group in theory.sentence_groups:
+            if sentence_group.docstring:
+                for line in sentence_group.docstring.splitlines():
+                    lines.append(f"# {line}")
+            for sentence in sentence_group.sentences or []:
+                lines.extend(self._sentence_lines(sentence))
+
+        if theory.ground_terms:
+            if lines and lines[-1] != "":
+                lines.append("")
+            for term in theory.ground_terms:
+                lines.extend(self._sentence_lines(term))
+
+        return "\n".join(lines)
+
+    def _predicate_definition(self, predicate_definition: PredicateDefinition) -> str:
+        arguments = ", ".join(
+            f"{name}: {self._type_expr(type_name)}" for name, type_name in predicate_definition.arguments.items()
+        )
+        return f"pred {predicate_definition.predicate}({arguments})."
+
+    def _sentence_lines(self, sentence: Sentence) -> list[str]:
+        lines: list[str] = []
+        comment = sentence.annotations.get("comment")
+        if comment:
+            for line in str(comment).splitlines():
+                lines.append(f"/// {line}")
+        lines.append(f"{self._sentence(sentence)}.")
+        return lines
+
+    def _sentence(self, sentence: Any, parenthesize: bool = False) -> str:
+        if isinstance(sentence, Forall):
+            result = f"all {self._variables(sentence.variables)} | {self._sentence(sentence.sentence)}"
+        elif isinstance(sentence, Exists):
+            result = f"exists {self._variables(sentence.variables)} | {self._sentence(sentence.sentence)}"
+        elif isinstance(sentence, Implies):
+            result = self._implication(sentence)
+        elif isinstance(sentence, Iff):
+            result = f"{self._sentence(sentence.left, True)} <-> {self._sentence(sentence.right, True)}"
+        elif isinstance(sentence, And):
+            result = self._boolean_sentence(sentence, " & ", "true")
+        elif isinstance(sentence, Or):
+            result = self._boolean_sentence(sentence, " | ", "false")
+        elif isinstance(sentence, Not):
+            result = f"~{self._sentence(sentence.negated, True)}"
+        elif isinstance(sentence, NegationAsFailure):
+            result = f"not {self._sentence(sentence.negated, True)}"
+        elif isinstance(sentence, Term):
+            result = self._term(sentence)
+        elif isinstance(sentence, Variable):
+            result = sentence.name
+        else:
+            result = self._value(sentence)
+
+        if parenthesize and isinstance(sentence, (Forall, Exists, Implies, Iff, And, Or)):
+            return f"({result})"
+        return result
+
+    def _implication(self, sentence: Implies) -> str:
+        antecedent = self._sentence(sentence.antecedent, True)
+        if isinstance(sentence.consequent, Or) and not sentence.consequent.operands:
+            return f":- {antecedent}"
+        consequent = self._sentence(sentence.consequent, True)
+        return f"{consequent} :- {antecedent}"
+
+    def _boolean_sentence(self, sentence: And | Or, separator: str, identity: str) -> str:
+        if not sentence.operands:
+            return identity
+        return separator.join(self._sentence(op, True) for op in sentence.operands)
+
+    def _term(self, term: Term) -> str:
+        operator = {
+            "eq": "=",
+            "ne": "!=",
+            "lt": "<",
+            "le": "<=",
+            "gt": ">",
+            "ge": ">=",
+            "add": "+",
+            "sub": "-",
+            "mul": "*",
+            "truediv": "/",
+            "pow": "**",
+        }.get(str(term.predicate))
+        if operator and len(term.values) == 2:
+            return f"{self._argument(term.values[0])} {operator} {self._argument(term.values[1])}"
+
+        predicate = term.predicate
+        if isinstance(predicate, Variable):
+            predicate_name = f"@{predicate.name}"
+        else:
+            predicate_name = str(predicate)
+        return f"{predicate_name}({', '.join(self._argument(value) for value in term.values)})"
+
+    def _argument(self, value: Any) -> str:
+        if isinstance(value, Sentence):
+            return self._sentence(value, True)
+        if isinstance(value, Variable):
+            return value.name
+        return self._value(value)
+
+    def _value(self, value: Any) -> str:
+        if isinstance(value, str):
+            return repr(value)
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+    def _variables(self, variables: list[Variable]) -> str:
+        return ", ".join(f"{var.name}: {var.domain}" if var.domain else var.name for var in variables)
+
+    def _type_expr(self, type_name: Any) -> str:
+        return str(type_name)

--- a/src/typedlogic/parsers/tlog_parser.py
+++ b/src/typedlogic/parsers/tlog_parser.py
@@ -134,8 +134,8 @@ arg_list: arg_expr ("," arg_expr)*
       | TRUE                                 -> true
       | FALSE                                -> false
 
-ALL.2: "all" | "forall"
-EXISTS.2: "exists" | "some"
+ALL.2: "all" | "forall" | "∀"
+EXISTS.2: "exists" | "some" | "∃"
 TYPE.2: "type" | "typedef"
 PRED.2: "pred" | "predicate" | "rel" | "relation"
 NAF.2: "not" | "\\+"
@@ -568,3 +568,50 @@ class TLogParser(Parser):
 
         visit(sentence)
         return variables
+
+
+class TLogMarkdownParser(TLogParser):
+    """Parse TLog blocks embedded in Markdown prose."""
+
+    default_suffix = "tlog.md"
+    code_block_languages = frozenset({"tlog", "typedlogic", "logic"})
+
+    def parse(self, source: Union[Path, str, TextIO], **kwargs: Any) -> Theory:
+        """Parse fenced TLog code blocks from Markdown into a theory."""
+        text = self._read_source(source)
+        return super().parse(self._extract_tlog_blocks(text), **kwargs)
+
+    def _extract_tlog_blocks(self, text: str) -> str:
+        blocks: list[str] = []
+        block_lines: list[str] = []
+        in_block = False
+        collecting = False
+        fence = ""
+
+        for line in text.splitlines():
+            stripped = line.strip()
+            if not in_block and self._starts_fence(stripped):
+                fence = stripped[:3]
+                language = stripped[3:].strip().split(maxsplit=1)[0].lower()
+                collecting = language in self.code_block_languages
+                in_block = True
+                block_lines = []
+                continue
+            if in_block and stripped.startswith(fence):
+                if collecting:
+                    blocks.append("\n".join(block_lines))
+                in_block = False
+                collecting = False
+                fence = ""
+                block_lines = []
+                continue
+            if collecting:
+                block_lines.append(line)
+
+        if in_block and collecting:
+            blocks.append("\n".join(block_lines))
+
+        return "\n\n".join(blocks)
+
+    def _starts_fence(self, stripped: str) -> bool:
+        return stripped.startswith("```") or stripped.startswith("~~~")

--- a/src/typedlogic/parsers/tlog_parser.py
+++ b/src/typedlogic/parsers/tlog_parser.py
@@ -1,0 +1,570 @@
+"""Parser for TypedLogic's ergonomic text rule syntax."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, TextIO, Union
+
+from lark import Lark, Transformer
+from lark.exceptions import LarkError
+
+from typedlogic import And, Exists, Forall, Iff, Implies, NegationAsFailure, Not, Or, PredicateDefinition, Term, Theory
+from typedlogic.datamodel import Sentence, Variable
+from typedlogic.parser import Parser, ValidationMessage
+
+GRAMMAR = r"""
+start: statement*
+
+statement: doc_comment* statement_body "."
+?statement_body: declaration
+               | constraint
+               | sentence
+
+doc_comment: DOC_COMMENT
+
+?declaration: type_decl
+            | predicate_decl
+
+type_decl: TYPE NAME [":" type_expr]
+predicate_decl: PRED NAME "/" INT                         -> predicate_arity_decl
+              | PRED NAME "(" [predicate_arg_list] ")"    -> predicate_signature_decl
+
+predicate_arg_list: predicate_arg ("," predicate_arg)*
+predicate_arg: NAME ":" type_expr
+type_expr: NAME
+
+constraint: IF sentence
+
+?sentence: quantifier
+         | implication
+
+quantifier: ALL var_decl_list "|" sentence     -> forall
+          | EXISTS var_decl_list "|" sentence  -> exists
+
+var_decl_list: var_decl ("," var_decl)*
+var_decl: var_name [":" type_expr]
+?var_name: NAME           -> bare_var_name
+         | QVAR           -> marked_var_name
+
+?implication: disjunction
+            | disjunction ARROW implication   -> implies
+            | disjunction RARROW implication  -> implies
+            | disjunction LARROW implication  -> implied
+            | disjunction IF implication      -> rule
+            | disjunction IFF implication     -> iff
+
+?disjunction: conjunction
+            | disjunction "|" conjunction     -> or_
+
+?conjunction: amp_conjunction
+            | conjunction "," amp_conjunction -> and_
+
+?amp_conjunction: unary
+                | amp_conjunction "&" unary   -> and_
+
+?unary: NAF unary                            -> naf
+      | "~" unary                            -> strict_not
+      | "!" unary                            -> strict_not
+      | comparison
+
+?comparison: sum
+           | sum "==" sum                    -> eq
+           | sum "=" sum                     -> eq
+           | sum "!=" sum                    -> ne
+           | sum "<=" sum                    -> le
+           | sum "<" sum                     -> lt
+           | sum ">=" sum                    -> ge
+           | sum ">" sum                     -> gt
+
+?sum: product
+    | sum "+" product                        -> add
+    | sum "-" product                        -> sub
+
+?product: power
+        | product "*" power                  -> mul
+        | product "/" power                  -> truediv
+
+?power: atom_expr
+      | atom_expr "**" power                 -> pow
+
+?atom_expr: atom
+          | value
+          | "(" sentence ")"
+
+atom: predicate_ref "(" [arg_list] ")"
+predicate_ref: NAME                          -> predicate_name
+             | PRED                          -> predicate_keyword_name
+             | HILOG_NAME                    -> hilog_predicate_name
+             | QVAR                          -> hilog_marked_predicate_name
+
+arg_list: arg_expr ("," arg_expr)*
+
+?arg_expr: arg_comparison
+
+?arg_comparison: arg_sum
+               | arg_sum "==" arg_sum         -> eq
+               | arg_sum "=" arg_sum          -> eq
+               | arg_sum "!=" arg_sum         -> ne
+               | arg_sum "<=" arg_sum         -> le
+               | arg_sum "<" arg_sum          -> lt
+               | arg_sum ">=" arg_sum         -> ge
+               | arg_sum ">" arg_sum          -> gt
+
+?arg_sum: arg_product
+        | arg_sum "+" arg_product             -> add
+        | arg_sum "-" arg_product             -> sub
+
+?arg_product: arg_power
+            | arg_product "*" arg_power       -> mul
+            | arg_product "/" arg_power       -> truediv
+
+?arg_power: arg_atom_expr
+          | arg_atom_expr "**" arg_power      -> pow
+
+?arg_atom_expr: atom
+              | value
+              | "(" arg_expr ")"
+
+?value: QVAR                                 -> marked_variable
+      | NAME                                 -> bare_name
+      | SIGNED_NUMBER                        -> number
+      | ESCAPED_STRING                       -> string
+      | SINGLE_QUOTED_STRING                 -> string
+      | TRUE                                 -> true
+      | FALSE                                -> false
+
+ALL.2: "all" | "forall"
+EXISTS.2: "exists" | "some"
+TYPE.2: "type" | "typedef"
+PRED.2: "pred" | "predicate" | "rel" | "relation"
+NAF.2: "not" | "\\+"
+IF: ":-"
+ARROW: "->"
+RARROW: "=>"
+LARROW: "<-"
+IFF: "<->" | "<=>"
+TRUE.2: "true"
+FALSE.2: "false"
+
+HILOG_NAME: "@" NAME
+QVAR: "?" NAME
+NAME: /[A-Za-z_][A-Za-z0-9_]*/
+SINGLE_QUOTED_STRING: /'([^'\\]|\\.)*'/
+DOC_COMMENT: /\/\/\/[^\n]*/
+COMMENT: /#[^\n]*/
+
+%import common.SIGNED_NUMBER
+%import common.INT
+%import common.ESCAPED_STRING
+%import common.WS
+%ignore WS
+%ignore COMMENT
+"""
+
+
+@dataclass(frozen=True)
+class NameRef:
+    """A bare or marked symbol that is resolved after statement context is known."""
+
+    name: str
+    variable: bool = False
+
+
+@dataclass(frozen=True)
+class PredicateRef:
+    """A predicate reference, optionally in variable predicate position."""
+
+    name: str
+    variable: bool = False
+
+
+@dataclass(frozen=True)
+class AtomNode:
+    """An atom before names have been resolved into variables or constants."""
+
+    predicate: PredicateRef
+    arguments: tuple[Any, ...]
+
+
+@dataclass(frozen=True)
+class UnaryNode:
+    """A unary connective before lowering."""
+
+    operator: str
+    operand: Any
+
+
+@dataclass(frozen=True)
+class BinaryNode:
+    """A binary connective or operator before lowering."""
+
+    operator: str
+    left: Any
+    right: Any
+
+
+@dataclass(frozen=True)
+class QuantifierNode:
+    """An explicitly quantified sentence before lowering."""
+
+    quantifier: str
+    variables: tuple[Variable, ...]
+    sentence: Any
+
+
+@dataclass(frozen=True)
+class ConstraintNode:
+    """A constraint of the form `:- body` before lowering."""
+
+    body: Any
+
+
+@dataclass(frozen=True)
+class PredicateArityDecl:
+    """A predicate declaration that gives only arity."""
+
+    name: str
+    arity: int
+
+
+@dataclass(frozen=True)
+class PredicateSignatureDecl:
+    """A predicate declaration with named typed arguments."""
+
+    name: str
+    arguments: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class TypeDecl:
+    """A type declaration."""
+
+    name: str
+    base: str = "str"
+
+
+@dataclass(frozen=True)
+class StatementNode:
+    """A parsed statement plus comments that should annotate it."""
+
+    comments: tuple[str, ...]
+    body: Any
+
+
+class _TreeToNodes(Transformer):
+    """Convert Lark parse trees into a small intermediate AST."""
+
+    def statement(self, items: list[Any]) -> StatementNode:
+        comments = tuple(item for item in items[:-1] if isinstance(item, str))
+        return StatementNode(comments=comments, body=items[-1])
+
+    def doc_comment(self, items: list[Any]) -> str:
+        token = str(items[0])
+        return token[3:].strip()
+
+    def type_expr(self, items: list[Any]) -> str:
+        return str(items[0])
+
+    def type_decl(self, items: list[Any]) -> TypeDecl:
+        name = str(items[1])
+        base = str(items[2]) if len(items) > 2 else "str"
+        return TypeDecl(name, base)
+
+    def predicate_arity_decl(self, items: list[Any]) -> PredicateArityDecl:
+        return PredicateArityDecl(str(items[1]), int(str(items[2])))
+
+    def predicate_signature_decl(self, items: list[Any]) -> PredicateSignatureDecl:
+        arguments = tuple(items[2]) if len(items) > 2 and isinstance(items[2], list) else ()
+        return PredicateSignatureDecl(str(items[1]), arguments)
+
+    def predicate_arg_list(self, items: list[Any]) -> list[tuple[str, str]]:
+        return list(items)
+
+    def predicate_arg(self, items: list[Any]) -> tuple[str, str]:
+        return str(items[0]), str(items[1])
+
+    def bare_var_name(self, items: list[Any]) -> str:
+        return str(items[0])
+
+    def marked_var_name(self, items: list[Any]) -> str:
+        return str(items[0])[1:]
+
+    def var_decl(self, items: list[Any]) -> Variable:
+        domain = str(items[1]) if len(items) > 1 else None
+        return Variable(str(items[0]), domain)
+
+    def var_decl_list(self, items: list[Any]) -> tuple[Variable, ...]:
+        return tuple(items)
+
+    def forall(self, items: list[Any]) -> QuantifierNode:
+        return QuantifierNode("forall", tuple(items[1]), items[2])
+
+    def exists(self, items: list[Any]) -> QuantifierNode:
+        return QuantifierNode("exists", tuple(items[1]), items[2])
+
+    def constraint(self, items: list[Any]) -> ConstraintNode:
+        return ConstraintNode(items[1])
+
+    def implies(self, items: list[Any]) -> BinaryNode:
+        return BinaryNode("implies", items[0], items[2])
+
+    def implied(self, items: list[Any]) -> BinaryNode:
+        return BinaryNode("implies", items[2], items[0])
+
+    def rule(self, items: list[Any]) -> BinaryNode:
+        return BinaryNode("implies", items[2], items[0])
+
+    def iff(self, items: list[Any]) -> BinaryNode:
+        return BinaryNode("iff", items[0], items[2])
+
+    def or_(self, items: list[Any]) -> BinaryNode:
+        return BinaryNode("or", items[0], items[1])
+
+    def and_(self, items: list[Any]) -> BinaryNode:
+        return BinaryNode("and", items[0], items[1])
+
+    def naf(self, items: list[Any]) -> UnaryNode:
+        return UnaryNode("naf", items[1])
+
+    def strict_not(self, items: list[Any]) -> UnaryNode:
+        return UnaryNode("not", items[0])
+
+    def eq(self, items: list[Any]) -> Term:
+        return Term("eq", items[0], items[1])
+
+    def ne(self, items: list[Any]) -> Term:
+        return Term("ne", items[0], items[1])
+
+    def le(self, items: list[Any]) -> Term:
+        return Term("le", items[0], items[1])
+
+    def lt(self, items: list[Any]) -> Term:
+        return Term("lt", items[0], items[1])
+
+    def ge(self, items: list[Any]) -> Term:
+        return Term("ge", items[0], items[1])
+
+    def gt(self, items: list[Any]) -> Term:
+        return Term("gt", items[0], items[1])
+
+    def add(self, items: list[Any]) -> Term:
+        return Term("add", items[0], items[1])
+
+    def sub(self, items: list[Any]) -> Term:
+        return Term("sub", items[0], items[1])
+
+    def mul(self, items: list[Any]) -> Term:
+        return Term("mul", items[0], items[1])
+
+    def truediv(self, items: list[Any]) -> Term:
+        return Term("truediv", items[0], items[1])
+
+    def pow(self, items: list[Any]) -> Term:
+        return Term("pow", items[0], items[1])
+
+    def predicate_name(self, items: list[Any]) -> PredicateRef:
+        return PredicateRef(str(items[0]))
+
+    def predicate_keyword_name(self, items: list[Any]) -> PredicateRef:
+        return PredicateRef(str(items[0]))
+
+    def hilog_predicate_name(self, items: list[Any]) -> PredicateRef:
+        return PredicateRef(str(items[0])[1:], variable=True)
+
+    def hilog_marked_predicate_name(self, items: list[Any]) -> PredicateRef:
+        return PredicateRef(str(items[0])[1:], variable=True)
+
+    def arg_list(self, items: list[Any]) -> tuple[Any, ...]:
+        return tuple(items)
+
+    def atom(self, items: list[Any]) -> AtomNode:
+        predicate = items[0]
+        arguments = ()
+        if len(items) > 1:
+            arguments = tuple(items[1])
+        return AtomNode(predicate, arguments)
+
+    def marked_variable(self, items: list[Any]) -> NameRef:
+        return NameRef(str(items[0])[1:], variable=True)
+
+    def bare_name(self, items: list[Any]) -> NameRef:
+        return NameRef(str(items[0]))
+
+    def number(self, items: list[Any]) -> Union[int, float]:
+        raw = str(items[0])
+        if "." in raw:
+            return float(raw)
+        return int(raw)
+
+    def string(self, items: list[Any]) -> str:
+        raw = str(items[0])
+        return bytes(raw[1:-1], "utf-8").decode("unicode_escape")
+
+    def true(self, items: list[Any]) -> bool:
+        return True
+
+    def false(self, items: list[Any]) -> bool:
+        return False
+
+
+class TLogParser(Parser):
+    """Parse ergonomic TypedLogic rules into the core datamodel."""
+
+    default_suffix = "tlog"
+
+    def __init__(self, implicit_universal: bool = True, **kwargs: Any):
+        """
+        Create a parser.
+
+        :param implicit_universal: Wrap unquantified rules containing variables in `Forall`.
+        :param kwargs: Forwarded to the base parser.
+        """
+        super().__init__(**kwargs)
+        self.implicit_universal = implicit_universal
+        self._parser = Lark(GRAMMAR, parser="lalr", propagate_positions=True, maybe_placeholders=False)
+
+    def parse(self, source: Union[Path, str, TextIO], **kwargs: Any) -> Theory:
+        """Parse a TLog source into a theory."""
+        text = self._read_source(source)
+        tree = self._parser.parse(text)
+        statement_nodes = _TreeToNodes().transform(tree)
+        theory = Theory()
+        for statement in statement_nodes.children:
+            self._add_statement(theory, statement)
+        return theory
+
+    def validate_iter(self, source: Union[Path, str, TextIO], **kwargs: Any) -> Iterable[ValidationMessage]:
+        """Validate source syntax."""
+        try:
+            self.parse(source, **kwargs)
+        except LarkError as e:
+            yield ValidationMessage(message=str(e))
+
+    def _read_source(self, source: Union[Path, str, TextIO]) -> str:
+        if isinstance(source, Path):
+            return source.read_text(encoding="utf-8")
+        if hasattr(source, "read"):
+            return source.read()
+        return str(source)
+
+    def _add_statement(self, theory: Theory, statement: StatementNode) -> None:
+        body = statement.body
+        if isinstance(body, TypeDecl):
+            theory.type_definitions[body.name] = body.base
+            return
+        if isinstance(body, PredicateArityDecl):
+            theory.predicate_definitions.append(
+                PredicateDefinition(body.name, {f"arg{i}": "str" for i in range(body.arity)})
+            )
+            return
+        if isinstance(body, PredicateSignatureDecl):
+            theory.predicate_definitions.append(PredicateDefinition(body.name, dict(body.arguments)))
+            return
+
+        sentence = self._lower_statement(body)
+        if statement.comments:
+            sentence.add_annotation("comment", "\n".join(statement.comments))
+        theory.add(sentence)
+
+    def _lower_statement(self, node: Any) -> Sentence:
+        explicit_vars = self._explicit_vars(node)
+        rule_like = bool(explicit_vars) or self._is_rule_like(node)
+        sentence = self._lower(node, explicit_vars, bare_names_as_variables=rule_like)
+        if explicit_vars:
+            return sentence
+        variables = self._sentence_variables(sentence)
+        if self.implicit_universal and variables and rule_like:
+            return Forall(variables, sentence)
+        return sentence
+
+    def _lower(self, node: Any, bound_vars: dict[str, Variable], bare_names_as_variables: bool) -> Any:
+        if isinstance(node, QuantifierNode):
+            local_vars = {**bound_vars, **{v.name: v for v in node.variables}}
+            sentence = self._lower(node.sentence, local_vars, bare_names_as_variables=False)
+            if node.quantifier == "forall":
+                return Forall(list(node.variables), sentence)
+            return Exists(list(node.variables), sentence)
+        if isinstance(node, ConstraintNode):
+            return Implies(self._lower(node.body, bound_vars, bare_names_as_variables), Or())
+        if isinstance(node, UnaryNode):
+            operand = self._lower(node.operand, bound_vars, bare_names_as_variables)
+            if node.operator == "naf":
+                return NegationAsFailure(operand)
+            return Not(operand)
+        if isinstance(node, BinaryNode):
+            left = self._lower(node.left, bound_vars, bare_names_as_variables)
+            right = self._lower(node.right, bound_vars, bare_names_as_variables)
+            if node.operator == "and":
+                return And(left, right)
+            if node.operator == "or":
+                return Or(left, right)
+            if node.operator == "implies":
+                return Implies(left, right)
+            if node.operator == "iff":
+                return Iff(left, right)
+            raise ValueError(f"Unknown operator: {node.operator}")
+        if isinstance(node, AtomNode):
+            predicate: Union[str, Variable] = node.predicate.name
+            if node.predicate.variable:
+                predicate = bound_vars.get(node.predicate.name, Variable(node.predicate.name))
+            args = [self._lower(arg, bound_vars, bare_names_as_variables) for arg in node.arguments]
+            return Term(predicate, *args)
+        if isinstance(node, Term):
+            args = [self._lower(arg, bound_vars, bare_names_as_variables) for arg in node.values]
+            return Term(node.predicate, *args)
+        if isinstance(node, NameRef):
+            if node.variable:
+                return bound_vars.get(node.name, Variable(node.name))
+            if node.name in bound_vars:
+                return bound_vars[node.name]
+            if bare_names_as_variables:
+                return Variable(node.name)
+            return node.name
+        if isinstance(node, bool):
+            return And() if node else Or()
+        return node
+
+    def _explicit_vars(self, node: Any) -> dict[str, Variable]:
+        if isinstance(node, QuantifierNode):
+            return {v.name: v for v in node.variables}
+        return {}
+
+    def _is_rule_like(self, node: Any) -> bool:
+        if isinstance(node, (ConstraintNode, QuantifierNode)):
+            return True
+        if isinstance(node, BinaryNode):
+            if node.operator in {"implies", "iff"}:
+                return True
+            return self._is_rule_like(node.left) or self._is_rule_like(node.right)
+        if isinstance(node, UnaryNode):
+            return self._is_rule_like(node.operand)
+        return False
+
+    def _sentence_variables(self, sentence: Any) -> list[Variable]:
+        variables: list[Variable] = []
+        seen: set[str] = set()
+
+        def visit(value: Any) -> None:
+            if isinstance(value, Variable):
+                if value.name not in seen:
+                    seen.add(value.name)
+                    variables.append(value)
+                return
+            if isinstance(value, Term):
+                if isinstance(value.predicate, Variable):
+                    visit(value.predicate)
+                for arg in value.values:
+                    visit(arg)
+                return
+            if isinstance(value, (Forall, Exists)):
+                for var in value.variables:
+                    seen.add(var.name)
+                visit(value.sentence)
+                return
+            if isinstance(value, (And, Or, Not, NegationAsFailure, Implies, Iff)):
+                for operand in value.operands:
+                    visit(operand)
+
+        visit(sentence)
+        return variables

--- a/tests/input/linkml_rules.md
+++ b/tests/input/linkml_rules.md
@@ -1,0 +1,24 @@
+# LinkML Rule Expansion Sketch
+
+This document keeps the explanatory prose outside the parsed theory. Only fenced
+`tlog` blocks are interpreted by the Markdown wrapper parser.
+
+```tlog
+type PointerID: str.
+type ElementID: str.
+
+pred pointer_type(id: PointerID, element: ElementID).
+pred class_slot(cls: ElementID, slot: str).
+pred required(slot: str).
+```
+
+The rule block can use symbolic quantifiers when that reads better in prose.
+
+```tlog
+/// Required slots must have at least one observed value.
+:- pointer_type(i, c), class_slot(c, s), required(s), not has_slot_value(i, s).
+
+∀ i, c | pointer_type(i, c) -> instance(i).
+
+∃ witness | observed(witness).
+```

--- a/tests/input/linkml_rules.tlog
+++ b/tests/input/linkml_rules.tlog
@@ -1,0 +1,20 @@
+type PointerID: str.
+type ElementID: str.
+type SlotID: str.
+
+pred pointer_type(id: PointerID, element: ElementID).
+pred class_slot(cls: ElementID, slot: SlotID).
+pred required(slot: SlotID).
+pred object_pointer_has_property_scalarized(id: PointerID, slot: SlotID, value: PointerID).
+
+/// Inherit slots through the class hierarchy.
+class_slot(c, s) :- is_a(c, p), class_slot(p, s).
+
+/// A reified closed-world helper for required slot constraints.
+has_slot_value(i, s) :- object_pointer_has_property_scalarized(i, s, v).
+
+/// Required slots must have at least one observed value.
+:- pointer_type(i, c), class_slot(c, s), required(s), not has_slot_value(i, s).
+
+/// HiLog-style predicate variable syntax can be represented for later macro expansion.
+all slot, i, v | @slot(i, v) -> has_slot_value(i, slot).

--- a/tests/test_hilog.py
+++ b/tests/test_hilog.py
@@ -1,0 +1,151 @@
+"""Tests for reified HiLog-like subclass propagation."""
+
+from typing import cast
+
+import pytest
+from typedlogic import Forall, PredicateDefinition, Term, Theory, Variable
+from typedlogic.compilers.fol_compiler import FOLCompiler
+from typedlogic.compilers.prolog_compiler import PrologCompiler
+from typedlogic.integrations.solvers.clingo.clingo_solver import ClingoSolver
+from typedlogic.integrations.solvers.problog.problog_compiler import ProbLogCompiler
+from typedlogic.integrations.solvers.souffle.souffle_compiler import SouffleCompiler
+from typedlogic.integrations.solvers.z3 import Z3Solver
+from typedlogic.integrations.solvers.z3.z3_compiler import Z3SExprCompiler
+from typedlogic.transformations import PrologConfig, as_prolog, to_horn_rules
+
+
+def meta_instantiation_theory() -> Theory:
+    """Build a first-order encoding of subclass propagation over reified instances."""
+    x = Variable("x", "str")
+    y = Variable("y", "str")
+    i = Variable("i", "str")
+    theory = Theory(
+        name="meta_instantiation",
+        predicate_definitions=[
+            PredicateDefinition("is_a", {"child": "str", "parent": "str"}),
+            PredicateDefinition("inst", {"instance": "str", "class": "str"}),
+        ],
+    )
+    theory.add(
+        Forall(
+            [x, y],
+            Term("is_a", x, y) >> Forall([i], Term("inst", i, x) >> Term("inst", i, y)),
+        )
+    )
+    return theory
+
+
+def true_hilog_theory() -> Theory:
+    """Build a true HiLog-style rule with variables in predicate position."""
+    x = Variable("x", "str")
+    y = Variable("y", "str")
+    i = Variable("i", "str")
+    theory = Theory(
+        name="true_hilog",
+        predicate_definitions=[
+            PredicateDefinition("isa", {"child": "str", "parent": "str"}),
+        ],
+    )
+    theory.add(
+        Forall(
+            [x, y],
+            Term("isa", x, y) >> Forall([i], Term(cast(str, x), i) >> Term(cast(str, y), i)),
+        )
+    )
+    return theory
+
+
+def check(condition: bool, message: str) -> None:
+    """Fail the test if the condition is false."""
+    if not condition:
+        pytest.fail(message)
+
+
+@pytest.mark.parametrize("solver_class", [Z3Solver, ClingoSolver])
+def test_meta_instantiation_rule_entails_parent_instantiation(solver_class):
+    """The reified inst/2 encoding works in both first-order and Datalog-style backends."""
+    solver = solver_class()
+    solver.add(meta_instantiation_theory())
+    solver.add(Term("is_a", "cat", "mammal"))
+    solver.add(Term("inst", "felix", "cat"))
+
+    check(solver.check().satisfiable is not False, "Expected the theory and facts to be satisfiable")
+    check(
+        solver.prove(Term("inst", "felix", "mammal")) is True,
+        "Expected inst(felix, mammal) to be entailed",
+    )
+
+
+def test_meta_instantiation_rule_lowers_to_horn_rule():
+    """Nested universal implication lowers to the Datalog rule used by Clingo-like targets."""
+    [rule] = to_horn_rules(meta_instantiation_theory().sentences[0])
+
+    check(
+        as_prolog(rule, PrologConfig(double_quote_strings=True)) == "inst(I, Y) :- is_a(X, Y), inst(I, X).",
+        f"Unexpected Horn rule: {rule}",
+    )
+
+
+def test_true_hilog_rule_can_be_represented_in_the_datamodel() -> None:
+    """The datamodel can hold predicate variables even though target compilers reject them."""
+    sentence = true_hilog_theory().sentences[0]
+
+    check("?x(?i) -> ?y(?i)" in str(sentence), f"Expected predicate variables in: {sentence}")
+
+
+def test_true_hilog_rule_is_not_directly_compilable_to_clingo() -> None:
+    """Clingo compilation currently assumes first-order terms with fixed predicate names."""
+    solver = ClingoSolver()
+    solver.add(true_hilog_theory())
+
+    with pytest.raises(AttributeError, match="lower"):
+        solver.dump()
+
+
+@pytest.mark.parametrize(
+    "compiler,expected_fragments",
+    [
+        (
+            FOLCompiler(),
+            [
+                "is_a(x, y)",
+                "inst(i, x)",
+                "inst(i, y)",
+            ],
+        ),
+        (
+            Z3SExprCompiler(),
+            [
+                "(forall ((x String) (y String))",
+                "(forall ((i String))",
+                "(=> (inst i x) (inst i y))",
+            ],
+        ),
+        (
+            PrologCompiler(),
+            [
+                "inst(I, Y) :- is_a(X, Y), inst(I, X).",
+            ],
+        ),
+        (
+            ProbLogCompiler(),
+            [
+                "inst(I, Y) :- is_a(X, Y), inst(I, X).",
+                "query(inst(Instance, Class)).",
+            ],
+        ),
+        (
+            SouffleCompiler(),
+            [
+                ".decl inst(instance: symbol, class: symbol)",
+                "inst(i, y) :- is_a(x, y), inst(i, x).",
+            ],
+        ),
+    ],
+)
+def test_meta_instantiation_rule_compiles_across_targets(compiler, expected_fragments: list[str]) -> None:
+    """Backends either preserve the quantifier structure or lower it to a Horn rule."""
+    compiled = compiler.compile(meta_instantiation_theory())
+
+    for fragment in expected_fragments:
+        check(fragment in compiled, f"Expected {fragment!r} in:\n{compiled}")

--- a/tests/test_hilog.py
+++ b/tests/test_hilog.py
@@ -3,6 +3,7 @@
 from typing import cast
 
 import pytest
+
 from typedlogic import Forall, PredicateDefinition, Term, Theory, Variable
 from typedlogic.compilers.fol_compiler import FOLCompiler
 from typedlogic.compilers.prolog_compiler import PrologCompiler

--- a/tests/test_tlog_cli.py
+++ b/tests/test_tlog_cli.py
@@ -1,0 +1,74 @@
+"""CLI tests for TLog parser/compiler integration."""
+
+from pathlib import Path
+
+import pytest
+from typedlogic.cli import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def check(condition: bool, message: str) -> None:
+    """Fail the test if the condition is false."""
+    if not condition:
+        pytest.fail(message)
+
+
+def test_convert_tlog_with_inferred_input_format(tmp_path: Path) -> None:
+    """TLog is available through the generic convert command."""
+    tlog_path = tmp_path / "family.tlog"
+    tlog_path.write_text(
+        """
+        type PersonID: str.
+        pred parent(parent: PersonID, child: PersonID).
+        pred ancestor(ancestor: PersonID, descendant: PersonID).
+        parent(Alice, Bob).
+        ancestor(x, y) :- parent(x, y).
+        """,
+        encoding="utf-8",
+    )
+
+    prolog = runner.invoke(app, ["convert", str(tlog_path), "-t", "prolog"])
+    check(prolog.exit_code == 0, prolog.stdout)
+    check("ancestor(X, Y) :- parent(X, Y)." in prolog.stdout, prolog.stdout)
+
+    tlog = runner.invoke(app, ["convert", str(tlog_path), "-t", "tlog"])
+    check(tlog.exit_code == 0, tlog.stdout)
+    check("pred parent(parent: PersonID, child: PersonID)." in tlog.stdout, tlog.stdout)
+    check("all x, y | ancestor(x, y) :- parent(x, y)." in tlog.stdout, tlog.stdout)
+
+
+def test_solve_tlog_with_selected_predicates_and_model_limit(tmp_path: Path) -> None:
+    """The generic solve command can filter materialized predicates and limit model output."""
+    pytest.importorskip("clingo")
+    tlog_path = tmp_path / "worlds.tlog"
+    tlog_path.write_text(
+        """
+        pred selected(option: str).
+        pred hidden(option: str).
+        selected("tea") | selected("coffee").
+        hidden("noise").
+        """,
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "solve",
+            str(tlog_path),
+            "--solver",
+            "clingo",
+            "--show",
+            "selected",
+            "--max-models",
+            "1",
+        ],
+    )
+
+    check(result.exit_code == 0, result.stdout)
+    check("Satisfiable: True" in result.stdout, result.stdout)
+    check("selected(" in result.stdout, result.stdout)
+    check("hidden(" not in result.stdout, result.stdout)
+    check("Total models shown: 1" in result.stdout, result.stdout)

--- a/tests/test_tlog_cli.py
+++ b/tests/test_tlog_cli.py
@@ -3,8 +3,9 @@
 from pathlib import Path
 
 import pytest
-from typedlogic.cli import app
 from typer.testing import CliRunner
+
+from typedlogic.cli import app
 
 runner = CliRunner()
 

--- a/tests/test_tlog_parser.py
+++ b/tests/test_tlog_parser.py
@@ -1,0 +1,246 @@
+"""Tests for the ergonomic TypedLogic text parser."""
+
+from pathlib import Path
+
+import pytest
+from typedlogic import Exists, Forall, Iff, Implies, NegationAsFailure, Not, Or, Term, Variable
+from typedlogic.compilers.prolog_compiler import PrologCompiler
+from typedlogic.integrations.solvers.souffle.souffle_compiler import SouffleCompiler
+from typedlogic.parsers.tlog_parser import TLogParser
+from typedlogic.registry import get_parser
+
+
+def check(condition: bool, message: str) -> None:
+    """Fail the test if the condition is false."""
+    if not condition:
+        pytest.fail(message)
+
+
+def parse_one(source: str):
+    """Parse source and return its only sentence."""
+    theory = TLogParser().parse(source)
+    check(len(theory.sentences) == 1, f"Expected one sentence, got {theory.sentences}")
+    return theory.sentences[0]
+
+
+def test_parse_type_and_predicate_declarations() -> None:
+    """Type and predicate declarations populate the Theory metadata."""
+    theory = TLogParser().parse(
+        """
+        type PointerID: str.
+        type ElementID.
+        pred PointerType(id: PointerID, element: ElementID).
+        pred edge/2.
+        pred Pred/1.
+        """
+    )
+
+    check(theory.type_definitions == {"PointerID": "str", "ElementID": "str"}, str(theory.type_definitions))
+    check(theory.predicate_definitions[0].predicate == "PointerType", str(theory.predicate_definitions))
+    check(theory.predicate_definitions[0].arguments == {"id": "PointerID", "element": "ElementID"}, "bad args")
+    check(theory.predicate_definitions[1].predicate == "edge", str(theory.predicate_definitions))
+    check(theory.predicate_definitions[1].arguments == {"arg0": "str", "arg1": "str"}, "bad arity args")
+    check(theory.predicate_definitions[2].predicate == "Pred", str(theory.predicate_definitions))
+
+
+def test_parse_case_preserving_facts_with_quoted_constants() -> None:
+    """Predicate case is preserved and quoted bare names are constants."""
+    theory = TLogParser().parse(
+        """
+        Pred("Alice").
+        pred("Alice").
+        knows(Alice, Bob).
+        """
+    )
+
+    check(
+        theory.sentences == [Term("Pred", "Alice"), Term("pred", "Alice"), Term("knows", "Alice", "Bob")],
+        repr(theory.sentences),
+    )
+
+
+def test_explicit_typed_forall_uses_declared_variable_names_without_case_assumptions() -> None:
+    """Explicit quantifiers allow lowercase or uppercase variables with optional domains."""
+    sentence = parse_one("all i: PointerID, C: ElementID | pointer_type(i, C) -> instance(i).")
+
+    check(isinstance(sentence, Forall), repr(sentence))
+    check([v.name for v in sentence.variables] == ["i", "C"], repr(sentence.variables))
+    check([v.domain for v in sentence.variables] == ["PointerID", "ElementID"], repr(sentence.variables))
+    check(repr(sentence.sentence) == "Implies(pointer_type(?i, ?C), instance(?i))", repr(sentence.sentence))
+
+
+def test_implicit_universal_variables_are_not_case_based() -> None:
+    """Unquantified rule variables are inferred from rule context, regardless of case."""
+    sentence = parse_one("ancestor(x, Y) :- parent(x, z) & ancestor(z, Y).")
+
+    check(isinstance(sentence, Forall), repr(sentence))
+    check([v.name for v in sentence.variables] == ["x", "z", "Y"], repr(sentence.variables))
+    check("ancestor(?x, ?Y)" in repr(sentence.sentence), repr(sentence.sentence))
+
+
+def test_comma_is_body_conjunction_without_stealing_term_argument_commas() -> None:
+    """Comma can be used as Prolog-style conjunction while predicate calls still parse multiple arguments."""
+    theory = TLogParser().parse(
+        """
+        pair(Alice, Bob).
+        ancestor(x, Y) :- parent(x, z), ancestor(z, Y).
+        """
+    )
+
+    check(theory.sentences[0] == Term("pair", "Alice", "Bob"), repr(theory.sentences[0]))
+    sentence = theory.sentences[1]
+    check(isinstance(sentence, Forall), repr(sentence))
+    check([v.name for v in sentence.variables] == ["x", "z", "Y"], repr(sentence.variables))
+    check("parent(?x, ?z)" in repr(sentence.sentence), repr(sentence.sentence))
+
+
+def test_rule_direction_variants_and_iff() -> None:
+    """Rules can be written in either direction, and equivalence has explicit syntax."""
+    theory = TLogParser().parse(
+        """
+        known(i) <- instance(i).
+        instance(i) => known(i).
+        all x | same(x) <-> equivalent(x).
+        """
+    )
+
+    left_arrow = theory.sentences[0]
+    right_arrow = theory.sentences[1]
+    iff = theory.sentences[2]
+    check(repr(left_arrow.sentence) == "Implies(instance(?i), known(?i))", repr(left_arrow))
+    check(repr(right_arrow.sentence) == "Implies(instance(?i), known(?i))", repr(right_arrow))
+    check(isinstance(iff, Forall), repr(iff))
+    check(isinstance(iff.sentence, Iff), repr(iff.sentence))
+
+
+def test_exists_quantifier() -> None:
+    """Existential quantifiers are explicit and do not depend on variable casing."""
+    sentence = parse_one("some witness | observed(witness).")
+
+    check(isinstance(sentence, Exists), repr(sentence))
+    check([v.name for v in sentence.variables] == ["witness"], repr(sentence.variables))
+    check(repr(sentence.sentence) == "observed(?witness)", repr(sentence.sentence))
+
+
+def test_question_mark_variables_disambiguate_without_explicit_forall() -> None:
+    """Question-mark variables are always variables and are implicitly universally quantified in rules."""
+    sentence = parse_one('likes(?person, "tea") -> happy(?person).')
+
+    check(isinstance(sentence, Forall), repr(sentence))
+    check([v.name for v in sentence.variables] == ["person"], repr(sentence.variables))
+    check(repr(sentence.sentence) == "Implies(likes(?person, tea), happy(?person))", repr(sentence.sentence))
+
+
+def test_parse_constraints_and_negation_as_failure() -> None:
+    """ASP-style constraints and `not` lower to false-headed implications with NAF."""
+    sentence = parse_one(":- pointer_type(i, c), required_slot(c, s), not has_slot_value(i, s).")
+
+    check(isinstance(sentence, Forall), repr(sentence))
+    inner = sentence.sentence
+    check(isinstance(inner, Implies), repr(inner))
+    check(isinstance(inner.consequent, Or), repr(inner.consequent))
+    check(any(isinstance(op, NegationAsFailure) for op in inner.antecedent.operands), repr(inner.antecedent))
+
+
+def test_parse_strict_negation_separately_from_naf() -> None:
+    """The `~` connective lowers to strict logical negation, not negation-as-failure."""
+    sentence = parse_one("p(x) -> ~q(x).")
+
+    check(isinstance(sentence, Forall), repr(sentence))
+    consequent = sentence.sentence.consequent
+    check(isinstance(consequent, Not), repr(consequent))
+
+
+def test_parse_infix_math_and_comparisons() -> None:
+    """Arithmetic and comparison syntax lower to builtin operator terms."""
+    sentence = parse_one("person_age(p, age) & age + 1 >= 18 -> adult(p).")
+
+    antecedent = sentence.sentence.antecedent
+    comparison = antecedent.operands[1]
+    check(isinstance(comparison, Term), repr(comparison))
+    check(comparison.predicate == "ge", repr(comparison))
+    check(isinstance(comparison.values[0], Term), repr(comparison.values[0]))
+    check(comparison.values[0].predicate == "add", repr(comparison.values[0]))
+
+
+def test_parse_hilog_predicate_variable_marker() -> None:
+    """The `@slot(...)` marker represents a variable in predicate position."""
+    sentence = parse_one("all slot, i, v | @slot(i, v) -> has_slot_value(i, slot).")
+
+    antecedent = sentence.sentence.antecedent
+    check(isinstance(antecedent.predicate, Variable), repr(antecedent))
+    check(antecedent.predicate.name == "slot", repr(antecedent.predicate))
+
+
+def test_doc_comments_attach_to_next_sentence() -> None:
+    """Triple-slash comments are preserved as sentence annotations."""
+    sentence = parse_one(
+        """
+        /// Required slots must have a value.
+        /// Missing values violate the closed-world check.
+        required(s) & class_slot(c, s) -> required_slot(c, s).
+        """
+    )
+
+    check(
+        sentence.annotations
+        == {"comment": "Required slots must have a value.\nMissing values violate the closed-world check."},
+        repr(sentence.annotations),
+    )
+
+
+def test_validate_iter_reports_syntax_errors() -> None:
+    """Validation reports parser errors without raising."""
+    messages = list(TLogParser().validate_iter("p(x) ->."))
+
+    check(len(messages) == 1, repr(messages))
+    check("Expected" in messages[0].message, messages[0].message)
+
+
+def test_registry_discovers_tlog_parser() -> None:
+    """The parser registry discovers TLogParser by class name."""
+    parser = get_parser("tlog")
+
+    check(isinstance(parser, TLogParser), repr(parser))
+
+
+def test_parse_literature_style_linkml_rules_example() -> None:
+    """The checked-in LinkML rule example exercises declarations, constraints, comments, and HiLog syntax."""
+    theory = TLogParser().parse(Path("tests/input/linkml_rules.tlog"))
+
+    check(theory.type_definitions["PointerID"] == "str", repr(theory.type_definitions))
+    check(len(theory.predicate_definitions) == 4, repr(theory.predicate_definitions))
+    check(len(theory.sentences) == 4, repr(theory.sentences))
+    check(theory.sentences[0].annotations["comment"] == "Inherit slots through the class hierarchy.", "bad comment")
+    check(isinstance(theory.sentences[-1].sentence.antecedent.predicate, Variable), repr(theory.sentences[-1]))
+
+
+def test_tlog_rules_export_to_existing_prolog_compiler() -> None:
+    """Non-HiLog TLog rules use the existing compiler pipeline."""
+    theory = TLogParser().parse(
+        """
+        pred parent(parent: str, child: str).
+        pred ancestor(ancestor: str, descendant: str).
+        ancestor(x, y) :- parent(x, y).
+        ancestor(x, y) :- parent(x, z) & ancestor(z, y).
+        """
+    )
+
+    compiled = PrologCompiler().compile(theory)
+    check("ancestor(X, Y) :- parent(X, Y)." in compiled, compiled)
+    check("ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y)." in compiled, compiled)
+
+
+def test_tlog_type_annotations_export_to_typed_souffle_compiler() -> None:
+    """Optional TLog type annotations are available to typed targets."""
+    theory = TLogParser().parse(
+        """
+        type PersonID: str.
+        pred parent(parent: PersonID, child: PersonID).
+        parent(Alice, Bob).
+        """
+    )
+
+    compiled = SouffleCompiler().compile(theory)
+    check(".type Personid = symbol" in compiled, compiled)
+    check(".decl parent(parent: Personid, child: Personid)" in compiled, compiled)

--- a/tests/test_tlog_parser.py
+++ b/tests/test_tlog_parser.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+
 from typedlogic import Exists, Forall, Iff, Implies, NegationAsFailure, Not, Or, Term, Variable
 from typedlogic.compilers.prolog_compiler import PrologCompiler
 from typedlogic.compilers.tlog_compiler import TLogCompiler

--- a/tests/test_tlog_parser.py
+++ b/tests/test_tlog_parser.py
@@ -5,9 +5,10 @@ from pathlib import Path
 import pytest
 from typedlogic import Exists, Forall, Iff, Implies, NegationAsFailure, Not, Or, Term, Variable
 from typedlogic.compilers.prolog_compiler import PrologCompiler
+from typedlogic.compilers.tlog_compiler import TLogCompiler
 from typedlogic.integrations.solvers.souffle.souffle_compiler import SouffleCompiler
 from typedlogic.parsers.tlog_parser import TLogMarkdownParser, TLogParser
-from typedlogic.registry import get_parser
+from typedlogic.registry import get_compiler, get_parser
 
 
 def check(condition: bool, message: str) -> None:
@@ -223,6 +224,13 @@ def test_registry_discovers_tlog_parser() -> None:
     check(isinstance(parser, TLogParser), repr(parser))
 
 
+def test_registry_discovers_tlog_compiler() -> None:
+    """The compiler registry discovers TLogCompiler by class name."""
+    compiler = get_compiler("tlog")
+
+    check(isinstance(compiler, TLogCompiler), repr(compiler))
+
+
 def test_registry_discovers_tlog_markdown_parser() -> None:
     """The parser registry discovers the Markdown wrapper parser by class name."""
     parser = get_parser("tlogmarkdown")
@@ -266,6 +274,29 @@ def test_tlog_rules_export_to_existing_prolog_compiler() -> None:
     compiled = PrologCompiler().compile(theory)
     check("ancestor(X, Y) :- parent(X, Y)." in compiled, compiled)
     check("ancestor(X, Y) :- parent(X, Z), ancestor(Z, Y)." in compiled, compiled)
+
+
+def test_tlog_compiler_roundtrips_core_tlog_constructs() -> None:
+    """The TLog compiler produces syntax that the TLog parser can read back."""
+    theory = TLogParser().parse(
+        """
+        type PersonID: str.
+        pred parent(parent: PersonID, child: PersonID).
+        pred ancestor(ancestor: PersonID, descendant: PersonID).
+        /// Direct parent links are ancestor links.
+        ancestor(x, y) :- parent(x, y).
+        parent(Alice, Bob).
+        """
+    )
+
+    compiled = TLogCompiler().compile(theory)
+    roundtripped = TLogParser().parse(compiled)
+    check("type PersonID: str." in compiled, compiled)
+    check("pred parent(parent: PersonID, child: PersonID)." in compiled, compiled)
+    check("/// Direct parent links are ancestor links." in compiled, compiled)
+    check(roundtripped.type_definitions == theory.type_definitions, repr(roundtripped.type_definitions))
+    check(roundtripped.predicate_definitions == theory.predicate_definitions, repr(roundtripped.predicate_definitions))
+    check(len(roundtripped.sentences) == len(theory.sentences), repr(roundtripped.sentences))
 
 
 def test_tlog_type_annotations_export_to_typed_souffle_compiler() -> None:

--- a/tests/test_tlog_parser.py
+++ b/tests/test_tlog_parser.py
@@ -6,7 +6,7 @@ import pytest
 from typedlogic import Exists, Forall, Iff, Implies, NegationAsFailure, Not, Or, Term, Variable
 from typedlogic.compilers.prolog_compiler import PrologCompiler
 from typedlogic.integrations.solvers.souffle.souffle_compiler import SouffleCompiler
-from typedlogic.parsers.tlog_parser import TLogParser
+from typedlogic.parsers.tlog_parser import TLogMarkdownParser, TLogParser
 from typedlogic.registry import get_parser
 
 
@@ -122,6 +122,25 @@ def test_exists_quantifier() -> None:
     check(repr(sentence.sentence) == "observed(?witness)", repr(sentence.sentence))
 
 
+def test_unicode_quantifier_symbols() -> None:
+    """Classic universal and existential quantifier symbols are accepted aliases."""
+    theory = TLogParser().parse(
+        """
+        ∀ i: PointerID, C: ElementID | pointer_type(i, C) -> instance(i).
+        ∃ witness | observed(witness).
+        """
+    )
+
+    universal = theory.sentences[0]
+    existential = theory.sentences[1]
+    check(isinstance(universal, Forall), repr(universal))
+    check([v.name for v in universal.variables] == ["i", "C"], repr(universal.variables))
+    check(universal.variables[0].domain == "PointerID", repr(universal.variables))
+    check(universal.variables[1].domain == "ElementID", repr(universal.variables))
+    check(isinstance(existential, Exists), repr(existential))
+    check([v.name for v in existential.variables] == ["witness"], repr(existential.variables))
+
+
 def test_question_mark_variables_disambiguate_without_explicit_forall() -> None:
     """Question-mark variables are always variables and are implicitly universally quantified in rules."""
     sentence = parse_one('likes(?person, "tea") -> happy(?person).')
@@ -204,6 +223,13 @@ def test_registry_discovers_tlog_parser() -> None:
     check(isinstance(parser, TLogParser), repr(parser))
 
 
+def test_registry_discovers_tlog_markdown_parser() -> None:
+    """The parser registry discovers the Markdown wrapper parser by class name."""
+    parser = get_parser("tlogmarkdown")
+
+    check(isinstance(parser, TLogMarkdownParser), repr(parser))
+
+
 def test_parse_literature_style_linkml_rules_example() -> None:
     """The checked-in LinkML rule example exercises declarations, constraints, comments, and HiLog syntax."""
     theory = TLogParser().parse(Path("tests/input/linkml_rules.tlog"))
@@ -213,6 +239,17 @@ def test_parse_literature_style_linkml_rules_example() -> None:
     check(len(theory.sentences) == 4, repr(theory.sentences))
     check(theory.sentences[0].annotations["comment"] == "Inherit slots through the class hierarchy.", "bad comment")
     check(isinstance(theory.sentences[-1].sentence.antecedent.predicate, Variable), repr(theory.sentences[-1]))
+
+
+def test_parse_literate_markdown_tlog_blocks() -> None:
+    """Markdown prose can wrap fenced TLog blocks without affecting the parsed theory."""
+    theory = TLogMarkdownParser().parse(Path("tests/input/linkml_rules.md"))
+
+    check(theory.type_definitions["PointerID"] == "str", repr(theory.type_definitions))
+    check(theory.predicate_definitions[0].predicate == "pointer_type", repr(theory.predicate_definitions))
+    check(len(theory.sentences) == 3, repr(theory.sentences))
+    check(isinstance(theory.sentences[1], Forall), repr(theory.sentences[1]))
+    check(isinstance(theory.sentences[2], Exists), repr(theory.sentences[2]))
 
 
 def test_tlog_rules_export_to_existing_prolog_compiler() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1507,6 +1507,15 @@ wheels = [
 ]
 
 [[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151 },
+]
+
+[[package]]
 name = "lark-parser"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3680,6 +3689,7 @@ name = "typedlogic"
 source = { editable = "." }
 dependencies = [
     { name = "importlib-metadata" },
+    { name = "lark" },
     { name = "typer" },
 ]
 
@@ -3756,6 +3766,7 @@ requires-dist = [
     { name = "clorm", marker = "extra == 'clorm'" },
     { name = "gavel-owl", marker = "extra == 'gavel-owl'" },
     { name = "importlib-metadata", specifier = ">=8.2.0" },
+    { name = "lark", specifier = ">=1.2.0" },
     { name = "llm", marker = "extra == 'llm'" },
     { name = "pandas", marker = "extra == 'pandas'" },
     { name = "pandera", extras = ["mypy"], marker = "extra == 'pandera'" },


### PR DESCRIPTION
## Summary
- Adds a Lark-based TLog parser and compiler, including Markdown/literate `.tlog.md` support.
- Adds HiLog-style examples with unicode quantifier parsing, including `forall`/`exists` and optional `∀`/`∃` syntax.
- Extends the generic CLI so `.tlog` is just another syntax for `convert`, `dump`, and `solve`, including selected predicate materialization and multiple-model output.
- Adds docs and notebook examples for authoring TLog, converting formats, and running inference through solvers such as clingo.

## Rebase / Conflict Resolution
- Rebasing onto `main` kept the uv/hatch project metadata from `main`.
- Dropped the obsolete `poetry.lock` from the feature branch.
- Preserved the new runtime parser dependency as `lark>=1.2.0` in `pyproject.toml`.
- Regenerated `uv.lock` so the TLog parser dependency is locked under the uv workflow.

## Validation
- `uv run ruff check src/typedlogic/compilers/tlog_compiler.py tests/test_tlog_parser.py tests/test_tlog_cli.py src/typedlogic/parsers/tlog_parser.py tests/test_hilog.py`
- `uv run ruff check src/typedlogic/cli.py --select E501,I,F,W291,W293`
- `uv run --extra pandas --extra clingo --extra z3 --extra problog pytest tests/test_tlog_parser.py tests/test_tlog_cli.py tests/test_hilog.py tests/test_cli.py::TestCLIWithValidation::test_list_parsers_includes_catalog -q`
- `uv run python -m json.tool docs/examples/tlog-cli.ipynb >/tmp/tlog-cli-ipynb.json`
- `uv run --extra pandas typedlogic convert docs/examples/tlog/ancestor.tlog -t tlog >/tmp/ancestor.tlog.out`
- `uv run --extra pandas typedlogic dump docs/examples/tlog/literate-rules.tlog.md -t prolog >/tmp/literate.pro`
- `uv run --extra pandas --extra clingo typedlogic solve docs/examples/tlog/worlds.tlog --solver clingo --show selected --max-models 2 >/tmp/worlds.solve`

Focused pytest result: `36 passed, 3 warnings`.

Notes:
- The default uv environment without extras currently fails while loading test `conftest.py` because `typedlogic.transformations` imports pandas unconditionally. The validation command includes the pandas extra.
- `mkdocs build --strict` is still blocked in this environment by WeasyPrint's missing native `libgobject-2.0-0` library.