### PR TITLE
[codex] Add LinkML schema reasoning layers

### DIFF
--- a/docs/integrations/frameworks/linkml/index.md
+++ b/docs/integrations/frameworks/linkml/index.md
@@ -4,3 +4,74 @@
 
 ::: typedlogic.integrations.frameworks.linkml.loader
 
+::: typedlogic.integrations.frameworks.linkml.reasoning
+
+## Reasoning Architecture
+
+The LinkML integration now uses two explicit logic layers.
+
+First, the loader maps a LinkML schema to reified TBox facts such as
+`class_definition/1`, `slot_definition/1`, `class_slot/2`, `slot_required/1`,
+and `slot_range/2`. This loader does not generate ABox validation rules in
+Python.
+
+Second, the schema preprocessing layer is authored as literate TLog in
+`src/typedlogic/integrations/frameworks/linkml/linkml_schema_rules.tlog.md`.
+Those rules are ordinary clingo-compatible predicates. They materialize facts
+such as `effective_class_slot/2`, `effective_range/3`, and normalized
+cardinality constraints, and they reject schema-level errors such as `is_a`
+cycles, missing parent classes, missing slot definitions, and inconsistent
+cardinality bounds.
+
+The compile-away layer then takes the materialized schema facts and emits direct
+ABox rules. It assumes data has already been lowered to unary class/type
+predicates and binary slot predicates:
+
+```tlog
+Person("p1").
+name("p1", "n1").
+string("n1").
+```
+
+For example, LinkML `required: true` plus `class_slot(Person, name)` compiles to
+a closed-world aggregate constraint equivalent to:
+
+```tlog
+:- Person(i), { name(i, v) : name(i, v) } <= 0.
+```
+
+Slot ranges compile to constraints over unary range predicates:
+
+```tlog
+:- Person(i), age(i, v), not integer(v).
+```
+
+The HiLog-style intended macros are documented separately in
+`src/typedlogic/integrations/frameworks/linkml/linkml_abox_macros.tlog.md`.
+They are parseable TLog, but are not sent directly to clingo because clingo does
+not support variable predicate position.
+
+## CLI
+
+LinkML schemas are still loaded through the generic parser path:
+
+```bash
+typedlogic dump schema.yaml -f linkml -t tlog
+typedlogic convert schema.yaml -f linkml -t prolog
+```
+
+The direct ABox compile-away API is currently Python-facing:
+
+```python
+from typedlogic import Term
+from typedlogic.integrations.frameworks.linkml.reasoning import validate_abox
+
+validate_abox(
+    schema,
+    [
+        Term("Person", "p1"),
+        Term("name", "p1", "n1"),
+        Term("string", "n1"),
+    ],
+)
+```

--- a/src/typedlogic/cli.py
+++ b/src/typedlogic/cli.py
@@ -144,7 +144,11 @@ def _guess_format(data_file: Path) -> str:
     return suffix
 
 
-def _combine_input_files(input_files: List[Path], validate_types: bool = True):
+def _combine_input_files(
+    input_files: List[Path],
+    validate_types: bool = True,
+    input_format: Optional[str] = None,
+):
     """
     Combine multiple input files into a single theory.
 
@@ -165,7 +169,7 @@ def _combine_input_files(input_files: List[Path], validate_types: bool = True):
     combined_theory = None
 
     for input_file in input_files:
-        file_format = _guess_format(input_file)
+        file_format = input_format or _guess_format(input_file)
         parser = get_parser(file_format)
 
         if validate_types and file_format == "python":
@@ -367,6 +371,7 @@ def solve(
 @app.command()
 def dump(
     input_files: List[Path] = typer.Argument(..., exists=True, dir_okay=False, readable=True),
+    input_format: Optional[str] = input_format_option,
     output_format: str = typer.Option("yaml", "--output-format", "-t", help="Output format (fol, yaml, prolog, etc.)"),
     output_file: Optional[Path] = output_file_option,
     validate_types: bool = typer.Option(
@@ -397,7 +402,7 @@ def dump(
     """
     # Combine all input files into a single theory
     try:
-        combined_theory = _combine_input_files(input_files, validate_types)
+        combined_theory = _combine_input_files(input_files, validate_types, input_format)
     except ValueError as e:
         click.echo(f"Error: {e}")
         raise typer.Exit(1)

--- a/src/typedlogic/integrations/frameworks/linkml/__init__.py
+++ b/src/typedlogic/integrations/frameworks/linkml/__init__.py
@@ -1,1 +1,24 @@
-from typedlogic.integrations.frameworks.linkml.meta import *
+"""LinkML integration helpers."""
+
+from typedlogic.integrations.frameworks.linkml.meta import *  # noqa: F403
+from typedlogic.integrations.frameworks.linkml.reasoning import (
+    check_schema as check_schema,
+)
+from typedlogic.integrations.frameworks.linkml.reasoning import (
+    compile_schema_to_abox as compile_schema_to_abox,
+)
+from typedlogic.integrations.frameworks.linkml.reasoning import (
+    load_abox_macro_rules as load_abox_macro_rules,
+)
+from typedlogic.integrations.frameworks.linkml.reasoning import (
+    load_schema_rules as load_schema_rules,
+)
+from typedlogic.integrations.frameworks.linkml.reasoning import (
+    materialize_schema as materialize_schema,
+)
+from typedlogic.integrations.frameworks.linkml.reasoning import (
+    schema_theory_from_object as schema_theory_from_object,
+)
+from typedlogic.integrations.frameworks.linkml.reasoning import (
+    validate_abox as validate_abox,
+)

--- a/src/typedlogic/integrations/frameworks/linkml/linkml_abox_macros.tlog.md
+++ b/src/typedlogic/integrations/frameworks/linkml/linkml_abox_macros.tlog.md
@@ -1,0 +1,44 @@
+# LinkML ABox Compile-Away Macros
+
+This document is intentionally written as parseable TLog but not as a direct
+clingo target.  The `@predicate(...)` form denotes variable predicate position:
+schema terms are expanded away before a concrete ABox theory is sent to clingo.
+
+Convention:
+
+- TBox predicates such as `effective_required/2` are ordinary clingo predicates.
+- ABox predicates such as `Person/1` and `name/2` are generated from LinkML
+  class, type, enum, and slot names.
+- The Python compile-away step only substitutes concrete predicate names; it
+  does not implement LinkML schema semantics directly.
+
+```tlog
+type ElementID: str.
+type SlotID: str.
+type PointerID: str.
+
+pred class_ancestor(cls: ElementID, ancestor: ElementID).
+pred effective_range(cls: ElementID, slot: SlotID, range: ElementID).
+pred effective_minimum_cardinality(cls: ElementID, slot: SlotID, count: int).
+pred effective_maximum_cardinality(cls: ElementID, slot: SlotID, count: int).
+```
+
+## Intended Macro Semantics
+
+```tlog
+/// Class hierarchy materialization:
+/// class_ancestor(C, P) + C(I) expands to P(I).
+all c, p, i | class_ancestor(c, p) & @c(i) -> @p(i).
+
+/// Range checks:
+/// effective_range(C, S, R) expands to an ABox constraint over C/1, S/2, and R/1.
+all c, s, r, i, v | effective_range(c, s, r) & @c(i) & @s(i, v) & not @r(v) -> false.
+
+/// Minimum cardinality:
+/// effective_minimum_cardinality(C, S, N) expands to a closed-world aggregate constraint.
+all c, s, n, i | effective_minimum_cardinality(c, s, n) & @c(i) -> has_at_least(i, s, n).
+
+/// Maximum cardinality:
+/// effective_maximum_cardinality(C, S, N) expands to a closed-world aggregate constraint.
+all c, s, n, i | effective_maximum_cardinality(c, s, n) & @c(i) -> has_at_most(i, s, n).
+```

--- a/src/typedlogic/integrations/frameworks/linkml/linkml_parser.py
+++ b/src/typedlogic/integrations/frameworks/linkml/linkml_parser.py
@@ -1,28 +1,24 @@
-from io import TextIOWrapper
 from pathlib import Path
-from typing import Any, Dict, List, Optional, TextIO, Union
+from typing import TextIO, Union
 
 import yaml
 
 from typedlogic import Theory
+from typedlogic.integrations.frameworks.linkml.reasoning import schema_theory_from_object
 from typedlogic.parser import Parser
-import typedlogic.integrations.frameworks.linkml.loader as linkml_loader
-from typedlogic.parsers.pyparser import PythonParser
 
 
 class LinkMLParser(Parser):
-    """
-    A parser for LinkML YAML files.
-    """
+    """A parser for LinkML YAML schema files."""
 
     def parse(self, source: Union[Path, str, TextIO], **kwargs) -> Theory:
         if isinstance(source, Path):
-            source = source.open()
-        if not isinstance(source, (str, TextIOWrapper)):
+            text = source.read_text(encoding="utf-8")
+        elif hasattr(source, "read"):
+            text = source.read()
+        elif isinstance(source, str):
+            text = source
+        else:
             raise ValueError(f"Invalid source type: {type(source)}")
-        obj = yaml.safe_load(source)
-        python_parser = PythonParser()
-        theory = python_parser.parse(linkml_loader)
-        # theory = Theory()
-        theory.extend(linkml_loader.generate_from_object(obj))
-        return theory
+        obj = yaml.safe_load(text)
+        return schema_theory_from_object(obj, include_schema_rules=kwargs.get("include_schema_rules", True))

--- a/src/typedlogic/integrations/frameworks/linkml/linkml_schema_rules.tlog.md
+++ b/src/typedlogic/integrations/frameworks/linkml/linkml_schema_rules.tlog.md
@@ -72,23 +72,28 @@ invalid_slot_usage(c, s) :- slot_usage(c, s), not effective_class_slot(c, s).
 ```tlog
 has_slot_range(s) :- slot_range(s, r).
 has_slot_usage_range(c, s) :- slot_usage_range(c, s, r).
+has_applicable_slot_usage_range(c, s) :- slot_usage_range(c, s, r).
+has_applicable_slot_usage_range(c, s) :- class_parent(c, p), has_applicable_slot_usage_range(p, s), not has_slot_usage_range(c, s).
 
 slot_effective_range(s, r) :- slot_range(s, r).
 slot_effective_range(s, "string") :- slot_definition(s), not has_slot_range(s).
 
-effective_range(c, s, r) :- effective_class_slot(c, s), slot_effective_range(s, r), not has_slot_usage_range(c, s).
 effective_range(c, s, r) :- slot_usage_range(c, s, r).
+effective_range(c, s, r) :- class_parent(c, p), effective_range(p, s, r), has_applicable_slot_usage_range(p, s), effective_class_slot(c, s), not has_slot_usage_range(c, s).
+effective_range(c, s, r) :- effective_class_slot(c, s), slot_effective_range(s, r), not has_applicable_slot_usage_range(c, s).
 
 invalid_range(c, s, r) :- effective_range(c, s, r), not range_definition(r).
 :- invalid_range(c, s, r).
 
 effective_required(c, s) :- effective_class_slot(c, s), slot_required(s), not slot_usage_required_false(c, s).
 effective_required(c, s) :- slot_usage_required(c, s).
+effective_required(c, s) :- class_parent(c, p), effective_required(p, s), effective_class_slot(c, s), not slot_usage_required_false(c, s), not slot_usage_required(c, s).
 
-effective_multivalued(c, s) :- effective_class_slot(c, s), slot_multivalued(s), not slot_usage_multivalued_false(c, s).
-effective_multivalued(c, s) :- slot_usage_multivalued(c, s).
-effective_singlevalued(c, s) :- effective_class_slot(c, s), not slot_multivalued(s), not slot_usage_multivalued(c, s).
-effective_singlevalued(c, s) :- slot_multivalued_false(s), effective_class_slot(c, s), not slot_usage_multivalued(c, s).
+has_applicable_multivalued(c, s) :- effective_class_slot(c, s), slot_multivalued(s), not slot_usage_multivalued_false(c, s).
+has_applicable_multivalued(c, s) :- slot_usage_multivalued(c, s).
+has_applicable_multivalued(c, s) :- class_parent(c, p), has_applicable_multivalued(p, s), effective_class_slot(c, s), not slot_usage_multivalued_false(c, s), not slot_usage_multivalued(c, s).
+effective_multivalued(c, s) :- has_applicable_multivalued(c, s).
+effective_singlevalued(c, s) :- effective_class_slot(c, s), not has_applicable_multivalued(c, s).
 effective_singlevalued(c, s) :- slot_usage_multivalued_false(c, s).
 ```
 
@@ -99,11 +104,13 @@ explicit_minimum_cardinality(c, s, n) :- effective_class_slot(c, s), slot_minimu
 explicit_minimum_cardinality(c, s, n) :- slot_usage_minimum_cardinality(c, s, n).
 explicit_minimum_cardinality(c, s, n) :- effective_class_slot(c, s), slot_exact_cardinality(s, n), not has_slot_usage_exact_cardinality(c, s).
 explicit_minimum_cardinality(c, s, n) :- slot_usage_exact_cardinality(c, s, n).
+explicit_minimum_cardinality(c, s, n) :- class_parent(c, p), explicit_minimum_cardinality(p, s, n), effective_class_slot(c, s), not has_slot_usage_minimum_cardinality(c, s), not has_slot_usage_exact_cardinality(c, s).
 
 explicit_maximum_cardinality(c, s, n) :- effective_class_slot(c, s), slot_maximum_cardinality(s, n), not has_slot_usage_maximum_cardinality(c, s).
 explicit_maximum_cardinality(c, s, n) :- slot_usage_maximum_cardinality(c, s, n).
 explicit_maximum_cardinality(c, s, n) :- effective_class_slot(c, s), slot_exact_cardinality(s, n), not has_slot_usage_exact_cardinality(c, s).
 explicit_maximum_cardinality(c, s, n) :- slot_usage_exact_cardinality(c, s, n).
+explicit_maximum_cardinality(c, s, n) :- class_parent(c, p), explicit_maximum_cardinality(p, s, n), effective_class_slot(c, s), not has_slot_usage_maximum_cardinality(c, s), not has_slot_usage_exact_cardinality(c, s).
 
 effective_exact_cardinality(c, s, n) :- effective_class_slot(c, s), slot_exact_cardinality(s, n), not has_slot_usage_exact_cardinality(c, s).
 effective_exact_cardinality(c, s, n) :- slot_usage_exact_cardinality(c, s, n).

--- a/src/typedlogic/integrations/frameworks/linkml/linkml_schema_rules.tlog.md
+++ b/src/typedlogic/integrations/frameworks/linkml/linkml_schema_rules.tlog.md
@@ -1,0 +1,131 @@
+# LinkML Schema Reasoning Rules
+
+These rules operate on reified LinkML schema/TBox facts such as
+`class_definition/1`, `slot_definition/1`, and `class_slot/2`.  This layer is
+intended to be compiled directly to clingo.
+
+```tlog
+type ElementID: str.
+type SlotID: str.
+type Count: int.
+
+pred class_definition(id: ElementID).
+pred slot_definition(id: SlotID).
+pred type_definition(id: ElementID).
+pred enum_definition(id: ElementID).
+pred is_a(element: ElementID, parent: ElementID).
+pred mixin(element: ElementID, parent: ElementID).
+pred class_slot(cls: ElementID, slot: SlotID).
+pred attribute(cls: ElementID, slot: SlotID).
+pred slot_usage(cls: ElementID, slot: SlotID).
+
+pred class_parent(cls: ElementID, parent: ElementID).
+pred class_ancestor(cls: ElementID, ancestor: ElementID).
+pred is_a_path(cls: ElementID, ancestor: ElementID).
+pred effective_class_slot(cls: ElementID, slot: SlotID).
+pred range_definition(id: ElementID).
+pred effective_range(cls: ElementID, slot: SlotID, range: ElementID).
+pred effective_required(cls: ElementID, slot: SlotID).
+pred effective_singlevalued(cls: ElementID, slot: SlotID).
+pred effective_multivalued(cls: ElementID, slot: SlotID).
+pred effective_minimum_cardinality(cls: ElementID, slot: SlotID, count: Count).
+pred effective_maximum_cardinality(cls: ElementID, slot: SlotID, count: Count).
+pred effective_exact_cardinality(cls: ElementID, slot: SlotID, count: Count).
+```
+
+## Element Closure And Schema Validity
+
+```tlog
+range_definition(r) :- class_definition(r).
+range_definition(r) :- type_definition(r).
+range_definition(r) :- enum_definition(r).
+
+slot_definition(s) :- attribute(c, s).
+class_slot(c, s) :- attribute(c, s).
+
+class_parent(c, p) :- is_a(c, p).
+class_parent(c, p) :- mixin(c, p).
+class_ancestor(c, p) :- class_parent(c, p).
+class_ancestor(c, a) :- class_parent(c, p), class_ancestor(p, a).
+
+is_a_path(c, p) :- is_a(c, p).
+is_a_path(c, a) :- is_a(c, p), is_a_path(p, a).
+
+invalid_is_a_cycle(c) :- is_a_path(c, c).
+invalid_parent_reference(c, p) :- class_definition(c), class_parent(c, p), not class_definition(p).
+invalid_class_slot(c, s) :- class_slot(c, s), not class_definition(c).
+invalid_class_slot(c, s) :- class_slot(c, s), not slot_definition(s).
+
+effective_class_slot(c, s) :- class_slot(c, s).
+effective_class_slot(c, s) :- class_parent(c, p), effective_class_slot(p, s).
+
+invalid_slot_usage(c, s) :- slot_usage(c, s), not effective_class_slot(c, s).
+
+:- invalid_is_a_cycle(c).
+:- invalid_parent_reference(c, p).
+:- invalid_class_slot(c, s).
+:- invalid_slot_usage(c, s).
+```
+
+## Slot Defaults And Overrides
+
+```tlog
+has_slot_range(s) :- slot_range(s, r).
+has_slot_usage_range(c, s) :- slot_usage_range(c, s, r).
+
+slot_effective_range(s, r) :- slot_range(s, r).
+slot_effective_range(s, "string") :- slot_definition(s), not has_slot_range(s).
+
+effective_range(c, s, r) :- effective_class_slot(c, s), slot_effective_range(s, r), not has_slot_usage_range(c, s).
+effective_range(c, s, r) :- slot_usage_range(c, s, r).
+
+invalid_range(c, s, r) :- effective_range(c, s, r), not range_definition(r).
+:- invalid_range(c, s, r).
+
+effective_required(c, s) :- effective_class_slot(c, s), slot_required(s), not slot_usage_required_false(c, s).
+effective_required(c, s) :- slot_usage_required(c, s).
+
+effective_multivalued(c, s) :- effective_class_slot(c, s), slot_multivalued(s), not slot_usage_multivalued_false(c, s).
+effective_multivalued(c, s) :- slot_usage_multivalued(c, s).
+effective_singlevalued(c, s) :- effective_class_slot(c, s), not slot_multivalued(s), not slot_usage_multivalued(c, s).
+effective_singlevalued(c, s) :- slot_multivalued_false(s), effective_class_slot(c, s), not slot_usage_multivalued(c, s).
+effective_singlevalued(c, s) :- slot_usage_multivalued_false(c, s).
+```
+
+## Cardinality Normalization
+
+```tlog
+explicit_minimum_cardinality(c, s, n) :- effective_class_slot(c, s), slot_minimum_cardinality(s, n), not has_slot_usage_minimum_cardinality(c, s).
+explicit_minimum_cardinality(c, s, n) :- slot_usage_minimum_cardinality(c, s, n).
+explicit_minimum_cardinality(c, s, n) :- effective_class_slot(c, s), slot_exact_cardinality(s, n), not has_slot_usage_exact_cardinality(c, s).
+explicit_minimum_cardinality(c, s, n) :- slot_usage_exact_cardinality(c, s, n).
+
+explicit_maximum_cardinality(c, s, n) :- effective_class_slot(c, s), slot_maximum_cardinality(s, n), not has_slot_usage_maximum_cardinality(c, s).
+explicit_maximum_cardinality(c, s, n) :- slot_usage_maximum_cardinality(c, s, n).
+explicit_maximum_cardinality(c, s, n) :- effective_class_slot(c, s), slot_exact_cardinality(s, n), not has_slot_usage_exact_cardinality(c, s).
+explicit_maximum_cardinality(c, s, n) :- slot_usage_exact_cardinality(c, s, n).
+
+effective_exact_cardinality(c, s, n) :- effective_class_slot(c, s), slot_exact_cardinality(s, n), not has_slot_usage_exact_cardinality(c, s).
+effective_exact_cardinality(c, s, n) :- slot_usage_exact_cardinality(c, s, n).
+effective_exact_cardinality(c, s, n) :- effective_minimum_cardinality(c, s, n), effective_maximum_cardinality(c, s, n).
+
+has_slot_usage_minimum_cardinality(c, s) :- slot_usage_minimum_cardinality(c, s, n).
+has_slot_usage_maximum_cardinality(c, s) :- slot_usage_maximum_cardinality(c, s, n).
+has_slot_usage_exact_cardinality(c, s) :- slot_usage_exact_cardinality(c, s, n).
+has_explicit_minimum_cardinality(c, s) :- explicit_minimum_cardinality(c, s, n).
+has_explicit_maximum_cardinality(c, s) :- explicit_maximum_cardinality(c, s, n).
+
+effective_minimum_cardinality(c, s, n) :- explicit_minimum_cardinality(c, s, n).
+effective_minimum_cardinality(c, s, 1) :- effective_required(c, s), not has_explicit_minimum_cardinality(c, s).
+
+effective_maximum_cardinality(c, s, n) :- explicit_maximum_cardinality(c, s, n).
+effective_maximum_cardinality(c, s, 1) :- effective_singlevalued(c, s), not has_explicit_maximum_cardinality(c, s).
+
+invalid_cardinality_bounds(c, s, min, max) :- effective_minimum_cardinality(c, s, min), effective_maximum_cardinality(c, s, max), min > max.
+invalid_exact_minimum(c, s, exact, min) :- effective_exact_cardinality(c, s, exact), explicit_minimum_cardinality(c, s, min), exact != min.
+invalid_exact_maximum(c, s, exact, max) :- effective_exact_cardinality(c, s, exact), explicit_maximum_cardinality(c, s, max), exact != max.
+
+:- invalid_cardinality_bounds(c, s, min, max).
+:- invalid_exact_minimum(c, s, exact, min).
+:- invalid_exact_maximum(c, s, exact, max).
+```

--- a/src/typedlogic/integrations/frameworks/linkml/loader.py
+++ b/src/typedlogic/integrations/frameworks/linkml/loader.py
@@ -1,59 +1,36 @@
 """
-Assumed pre-processing:
+Load LinkML schemas as reified TBox facts.
 
-- defaults:
-    - if an axiom refers to the metaproperty P of a slot S, then defaults are NOT applied
-        - default_range
-        - multivalued
-        - inlined (false)
-
-closed-world reasoning for required=True
-
-if we place this on the LHS it doesn't act as a constraint; so we need to treat it the same as range etc
-where we have separate disjointness constraints; e.g.
-
-ExpectedAssoc(i, "s") ; ... : - cls(i),
-
-# then
-
-:- ExpectedAssoc(i, s), {...}=0.
-
+The loader deliberately does not expand LinkML metamodel semantics into Python
+rules.  It emits a compact relational representation of the schema; the schema
+reasoning rules and the ABox compile-away layer live in :mod:`reasoning`.
 """
 
-from typing import Any, Dict, Iterator, List, Union
+from __future__ import annotations
 
-from typedlogic import And, Exists, Forall, Implies, Or, PredicateDefinition, Sentence, Term, Variable, Xor, \
-    NegationAsFailure
-from typedlogic.datamodel import CardinalityConstraint
-from typedlogic.integrations.frameworks.linkml.instance import (
-    ObjectPointerHasPropertyScalarized,
-    InlinedObject,
-    PointerType,
-    PointerIsCollection,
-    PointerIsScalar, InstSlotRequired,
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any
+
+from typedlogic import Term
+
+SchemaDict = Mapping[str, Any]
+
+PRIMITIVE_TYPES = (
+    "string",
+    "integer",
+    "float",
+    "double",
+    "decimal",
+    "boolean",
+    "date",
+    "datetime",
+    "uri",
+    "uriorcurie",
 )
-from typedlogic.integrations.frameworks.linkml.meta import (
-    ClassDefinition,
-    ClassSlot,
-    Identifier,
-    IsA,
-    Mixin,
-    TreeRoot,
-    TypeDefinition,
-)
-from typedlogic.theories.jsonlog.jsonlog import PointerIsArray, ObjectPointerHasProperty
 
-Result = Union[Sentence, PredicateDefinition]
-
-SchemaDict = Dict[str, Any]
 
 def remove_empty_kvs(obj: Any) -> Any:
-    """
-    Remove empty values from a dictionary.
-
-    :param obj: The dictionary to clean.
-    :return: A new dictionary with empty values removed.
-    """
+    """Remove ``None`` values from a schema-like object."""
     if isinstance(obj, dict):
         return {k: remove_empty_kvs(v) for k, v in obj.items() if v is not None}
     if isinstance(obj, list):
@@ -61,339 +38,145 @@ def remove_empty_kvs(obj: Any) -> Any:
     return obj
 
 
-def closed_world_constraint(pre: Sentence, post: Sentence) -> Sentence:
+def generate_from_object(obj: SchemaDict) -> Iterator[Term]:
     """
-    Generate a closed-world constraint that states if pre is true, then post must also be true.
+    Generate reified LinkML TBox facts from a schema dictionary.
 
-    Example:
-
-        >>> from typedlogic.datamodel import Term
-        >>> closed_world_constraint(Term("P"), Term("Q"))
-        Implies(And(P, NegationAsFailure(Q)), Or())
-
-    :param pre: The precondition sentence.
-    :param post: The postcondition sentence.
-    :return: A sentence representing the closed-world constraint.
+    Predicate names intentionally use the classic logic spelling used by the
+    TLog rules, for example ``class_definition/1``, ``slot_definition/1``, and
+    ``class_slot/2``.
     """
-    return Implies(And(pre, NegationAsFailure(post)), Or())
+    schema = remove_empty_kvs(dict(obj))
+    schema_id = schema.get("id") or schema.get("name")
+    if schema_id:
+        yield Term("schema_definition", str(schema_id))
+
+    yielded_types = set()
+    for type_name in PRIMITIVE_TYPES:
+        yielded_types.add(type_name)
+        yield Term("type_definition", type_name)
+
+    for type_name, type_defn in _items(schema.get("types")):
+        yielded_types.add(type_name)
+        yield from generate_type_definition(type_name, type_defn or {})
+
+    for enum_name, enum_defn in _items(schema.get("enums")):
+        yield from generate_enum_definition(enum_name, enum_defn or {})
+
+    for slot_name, slot_defn in _items(schema.get("slots")):
+        yield from generate_slot_definition(slot_name, slot_defn or {})
+
+    for class_name, class_defn in _items(schema.get("classes")):
+        yield from generate_class_definition(class_name, class_defn or {})
 
 
-def generate_from_object(obj: SchemaDict) -> Iterator[Sentence]:
-    """
-    Generates logical sentence in the LinkML predicate metamodel based on
-    an object/dict representation.
+def generate_class_definition(class_name: str, class_defn: Mapping[str, Any]) -> Iterator[Term]:
+    """Generate facts for one LinkML class definition."""
+    yield Term("class_definition", class_name)
+    if class_defn.get("tree_root") is True:
+        yield Term("tree_root", class_name)
+    yield from _element_parent_facts(class_name, class_defn)
 
-    :param obj:
-    :return:
-    """
-    obj = remove_empty_kvs(obj)
-    for k, v in obj.items():
-        if k == "classes":
-            for class_name, class_defn in v.items():
-                yield from generate_class_definition(class_name, class_defn)
-        elif k == "types":
-            for type_name, type_defn in v.items():
-                yield from generate_type_definition(type_name, type_defn)
-        elif k == "slots":
-            for slot_name, slot_defn in v.items():
-                yield from generate_slot_definition(slot_name, slot_defn)
-    return
+    for slot_name in _as_list(class_defn.get("slots")):
+        yield Term("class_slot", class_name, str(slot_name))
 
-def generate_slot_definition(slot_name: str, slot_defn: Dict) -> Iterator[Sentence]:
-    """
-    Maps an individual LinkML slot definition to a set of sentences.
+    for slot_name, slot_expr in _items(class_defn.get("attributes")):
+        yield Term("attribute", class_name, slot_name)
+        yield Term("slot_definition", slot_name)
+        yield Term("class_slot", class_name, slot_name)
+        yield from _slot_expression_facts("slot", (slot_name,), slot_expr or {})
 
-        >>> from typedlogic.compiler import write_sentences
-        >>> inst_var = Variable("I")
-        >>> slot_name = "age"
-        >>> write_sentences(generate_slot_definition(slot_name, {"required": True}))
-        ∀[I C]. ClassSlot(C, 'age') ∧ PointerType(I, C) → InstSlotRequired(I, 'age')
-
-    :param slot_name:
-    :param slot_defn:
-    :return:
-    """
-    inst_var = Variable("I")
-    class_name = Variable("C")
-    conjs = []
-    for conj in conjunctions_from_slot_expression(inst_var, slot_name, slot_defn):
-        conjs.append(conj)
-    if conjs:
-        yield Forall(
-            [inst_var, class_name],
-            Implies(
-                And(
-                    Term(ClassSlot.__name__, class_name, slot_name),
-                    Term(PointerType.__name__, inst_var, class_name),
-                ),
-                And(*conjs)))
+    for slot_name, slot_expr in _items(class_defn.get("slot_usage")):
+        yield Term("slot_usage", class_name, slot_name)
+        yield from _slot_expression_facts("slot_usage", (class_name, slot_name), slot_expr or {})
 
 
-
-def generate_class_definition(class_name: str, class_defn: Dict) -> Iterator[Sentence]:
-    """
-    Maps an individual LinkML class definition to a set of sentences.
-
-    Each class definition is treated as a collection of universally quantified sentences, of the form
-    for all i, if i is an instance of class_name, then i satisfies the following conditions <...>
-
-    Simple classes become ground unary terms:
-
-        >>> from typedlogic.compiler import write_sentences
-        >>> write_sentences(generate_class_definition("C", {}))
-        ClassDefinition('C')
-
-    For constructs such as inheritance, direct translations of the model are provided, in
-    addition to horn rules
-
-        >>> write_sentences(generate_class_definition("C", {"is_a": "D"}))
-        ClassDefinition('C')
-        IsA('C', 'D')
-        ∀[I]. PointerType(I, 'C') → PointerType(I, 'D')
-
-    i.e. if I instance an instance of C, it's a member of D
-
-    Constraints:
-
-        >>> write_sentences(generate_class_definition("C", {"attributes": {"a1": {"required": True}}}))
-        ClassDefinition('C')
-        ∀[I]. PointerType(I, 'C') → InstSlotRequired(I, 'a1')
-
-    Ranges:
-
-        >>> write_sentences(generate_class_definition("C", {"attributes": {"a1": {"range": "integer"}}}))
-        ClassDefinition('C')
-        ∀[I]. PointerType(I, 'C') → ∀[v]. ObjectPointerHasPropertyScalarized(I, 'a1', v) → PointerType(v, 'integer')
-
-    Combinations:
-
-        >>> write_sentences(generate_class_definition("C", {"attributes": {"a1": {"required": True, "range": "string"}}}))
-        ClassDefinition('C')
-        ∀[I]. PointerType(I, 'C') → InstSlotRequired(I, 'a1') ∧ ∀[v]. ObjectPointerHasPropertyScalarized(I, 'a1', v) → PointerType(v, 'string')
-
-    Booleans:
-
-        >>> write_sentences(generate_class_definition("C", {"attributes": {"a1": {"any_of": [{"required": True}, {"range": "string"}]}}}))
-        ClassDefinition('C')
-        ∀[I]. PointerType(I, 'C') → (InstSlotRequired(I, 'a1') ∨ ∀[v]. ObjectPointerHasPropertyScalarized(I, 'a1', v) → PointerType(v, 'string'))
-
-    Cardinality:
-
-        >>> write_sentences(generate_class_definition("C", {"attributes": {"a1": {"multivalued": False}}}))
-        ClassDefinition('C')
-        ∀[I]. PointerType(I, 'C') → ∀[v]. ObjectPointerHasProperty(I, 'a1', v) → PointerIsScalar(v)
-
-    Allowed slots:
-
-        >>> write_sentences(generate_class_definition("C", {"slots": ["s1"]}))
-        ClassDefinition('C')
-        ClassSlot('C', 's1')
+def generate_slot_definition(slot_name: str, slot_defn: Mapping[str, Any]) -> Iterator[Term]:
+    """Generate facts for one LinkML slot definition."""
+    yield Term("slot_definition", slot_name)
+    yield from _element_parent_facts(slot_name, slot_defn)
+    yield from _slot_expression_facts("slot", (slot_name,), slot_defn)
 
 
-    :param class_name:
-    :param class_defn:
-    :return:
-    """
-    yield ClassDefinition(class_name)
-    inst_var = Variable("I")
-    conjs: List[Sentence] = []
-    for k, v in class_defn.items():
-        if k in ("slot_usage", "attributes"):
-            for slot_name, slot_defn in v.items():
-                for attr_k, attr_v in slot_defn.items():
-                    # special case - not expanded
-                    if attr_k == "identifier":
-                        yield Identifier(class_name, slot_name)
-                for conj in conjunctions_from_slot_expression(inst_var, slot_name, slot_defn):
-                    conjs.append(conj)
-        if k == "slots":
-            for slot_name in v:
-                yield ClassSlot(class_name, slot_name)
-        if k == "is_a":
-            yield IsA(class_name, v)
-            yield Forall(
-                [inst_var],
-                Implies(
-                    Term(PointerType.__name__, inst_var, class_name),
-                    Term(PointerType.__name__, inst_var, v),
-                ),
-            )
-        if k == "mixins":
-            for v1 in v:
-                yield Mixin(class_name, v1)
-                yield Forall(
-                    [inst_var],
-                    Implies(
-                        Term(PointerType.__name__, inst_var, class_name),
-                        Term(PointerType.__name__, inst_var, v1),
-                    ),
-                )
-        if k == "tree_root":
-            yield TreeRoot(class_name)
-            yield PointerType("/", class_name)
-    if conjs:
-        yield Forall([inst_var], Implies(Term(PointerType.__name__, inst_var, class_name), And(*conjs)))
-    return
+def generate_type_definition(type_name: str, type_defn: Mapping[str, Any]) -> Iterator[Term]:
+    """Generate facts for one LinkML type definition."""
+    yield Term("type_definition", type_name)
+    if parent := type_defn.get("typeof"):
+        yield Term("is_a", type_name, str(parent))
+    yield from _element_parent_facts(type_name, type_defn)
 
 
-def generate_type_definition(type_name: str, type_defn: Dict) -> Iterator[Sentence]:
-    """
-    Maps an individual LinkML type definition to a set of sentences.
-
-    Each type definition is treated as a collection of universally quantified sentences, of the form
-    for all i, if i is an instance of class_name, then i satisfies the following conditions <...>
-
-    Simple classes become ground unary terms:
-
-        >>> from typedlogic.compiler import write_sentences
-        >>> write_sentences(generate_type_definition("T", {}))
-        TypeDefinition('T')
-
-    For constructs such as inheritance, direct translations of the model are provided, in
-    addition to horn rules
-
-        >>> write_sentences(generate_type_definition("T", {"typeof": "U"}))
-        TypeDefinition('T')
-        IsA('T', 'U')
-        ∀[i]. PointerType(i, 'T') → PointerType(i, 'U')
+def generate_enum_definition(enum_name: str, enum_defn: Mapping[str, Any]) -> Iterator[Term]:
+    """Generate facts for one LinkML enum definition."""
+    yield Term("enum_definition", enum_name)
+    yield from _element_parent_facts(enum_name, enum_defn)
 
 
-    TODO: complete this
+def _slot_expression_facts(prefix: str, args: tuple[str, ...], slot_expr: Mapping[str, Any]) -> Iterator[Term]:
+    """Generate facts for the LinkML SlotExpression metaslots used by reasoning."""
+    bool_slots = {
+        "required",
+        "recommended",
+        "multivalued",
+        "identifier",
+        "key",
+        "designates_type",
+        "inlined",
+        "inlined_as_list",
+        "transitive",
+    }
+    value_slots = {
+        "range",
+        "pattern",
+        "minimum_cardinality",
+        "maximum_cardinality",
+        "exact_cardinality",
+        "equals_string",
+        "equals_number",
+        "equals_expression",
+    }
 
-    :param type_name:
-    :param type_defn:
-    :return:
-    """
-    yield TypeDefinition(type_name)
-    inst_var = Variable("i")
-    conjs: List[Sentence] = []
-    for k, v in type_defn.items():
-        if k == "typeof":
-            yield IsA(type_name, v)
-            yield Forall(
-                [inst_var],
-                Implies(
-                    Term(PointerType.__name__, inst_var, type_name),
-                    Term(PointerType.__name__, inst_var, v),
-                ),
-            )
-        if k == "mixins":
-            for v1 in v:
-                yield Forall(
-                    [inst_var],
-                    Implies(
-                        Term(PointerType.__name__, inst_var, type_name),
-                        Term(PointerType.__name__, inst_var, v1),
-                    ),
-                )
-        # for conj in conjunctions_from_type_expression(inst_var, type_name, type_defn):
-        #    conjs.append(conj)
-    if conjs:
-        yield Forall([inst_var], Implies(Term(PointerType.__name__, inst_var, type_name), And(*conjs)))
-    return
+    for key in sorted(bool_slots):
+        if key in slot_expr:
+            fact_name = f"{prefix}_{key}"
+            if slot_expr[key] is True:
+                yield Term(fact_name, *args)
+            elif slot_expr[key] is False:
+                yield Term(f"{fact_name}_false", *args)
+
+    for key in sorted(value_slots):
+        value = slot_expr.get(key)
+        if value is not None:
+            yield Term(f"{prefix}_{key}", *args, value)
+
+    for value in _as_list(slot_expr.get("equals_string_in")):
+        yield Term(f"{prefix}_equals_string_in", *args, str(value))
+
+    for expression_kind in ("any_of", "all_of", "none_of", "exactly_one_of"):
+        for index, expression in enumerate(_as_list(slot_expr.get(expression_kind))):
+            expression_id = ":".join((*args, expression_kind, str(index)))
+            yield Term(f"{prefix}_{expression_kind}", *args, expression_id)
+            yield from _slot_expression_facts("anonymous_slot_expression", (expression_id,), expression or {})
 
 
-def conjunctions_from_slot_expression(inst_var: Variable, slot_name: str, slot_expr: Dict) -> Iterator[Sentence]:
-    """
-    Generate a set of conjunctions from a slot expression
+def _element_parent_facts(element_name: str, definition: Mapping[str, Any]) -> Iterator[Term]:
+    if parent := definition.get("is_a"):
+        yield Term("is_a", element_name, str(parent))
+    for mixin in _as_list(definition.get("mixins")):
+        yield Term("mixin", element_name, str(mixin))
 
-        >>> from typedlogic.compiler import write_sentences
-        >>> inst_var = Variable("I")
-        >>> slot_name = "age"
-        >>> write_sentences(conjunctions_from_slot_expression(inst_var, slot_name, {"required": True}))
-        InstSlotRequired(I, 'age')
-        >>> write_sentences(conjunctions_from_slot_expression(inst_var, slot_name, {"range": "string"}))
-        ∀[v]. ObjectPointerHasPropertyScalarized(I, 'age', v) → PointerType(v, 'string')
-        >>> any_of = {"any_of": [{"range": "string"}, {"range": "integer"}]}
-        >>> write_sentences(conjunctions_from_slot_expression(inst_var, slot_name, any_of))
-        (∀[v]. ObjectPointerHasPropertyScalarized(I, 'age', v) → PointerType(v, 'string') ∨ ∀[v]. ObjectPointerHasPropertyScalarized(I, 'age', v) → PointerType(v, 'integer'))
 
-    :param inst_var:
-    :param slot_name:
-    :param slot_expr:
-    :return:
-    """
-    val_var = Variable("v")
-    assert val_var.name == "v"
-    for k, v in slot_expr.items():
-        if k == "any_of":
-            or_exprs = []
-            for sub_expr in v:
-                or_exprs.extend(list(conjunctions_from_slot_expression(inst_var, slot_name, sub_expr)))
-            yield Or(*or_exprs)
-        elif k == "all_of":
-            and_exprs = []
-            for sub_expr in v:
-                and_exprs.extend(list(conjunctions_from_slot_expression(inst_var, slot_name, sub_expr)))
-            yield And(*and_exprs)
-        elif k == "none_of":
-            none_exprs = []
-            for sub_expr in v:
-                none_exprs.extend(list(conjunctions_from_slot_expression(inst_var, slot_name, sub_expr)))
-            if len(none_exprs) == 1:
-                yield ~none_exprs[0]
-            else:
-                yield ~And(*none_exprs)
-        elif k == "exactly_one_of":
-            or_exprs = []
-            for sub_expr in v:
-                or_exprs.extend(list(conjunctions_from_slot_expression(inst_var, slot_name, sub_expr)))
-            yield Xor(*or_exprs)
-        elif k == "required":
-            if v:
-                yield Term(InstSlotRequired.__name__, inst_var, slot_name)
-        # elif k == "identifier":
-        #    yield Identifier(class_name, slot_name)
-        elif k == "range":
-            # assumes pre-processing has decorated the range with the appropriate type
-            # TODO: linkml:Any
-            if v:
-                yield Forall(
-                    [val_var],
-                    Implies(
-                        Term(ObjectPointerHasPropertyScalarized.__name__, inst_var, slot_name, val_var),
-                        Term(PointerType.__name__, val_var, v),
-                    ),
-                )
-        elif k == "multivalued" and v is not None:
-            if v is True:
-                pred = PointerIsCollection.__name__
-            else:
-                pred = PointerIsScalar.__name__
-            yield Forall(
-                [val_var], Implies(Term(ObjectPointerHasProperty.__name__, inst_var, slot_name, val_var), Term(pred, val_var))
-            )
-        elif k == "inlined_as_list" and v is True:
-            yield Forall(
-                [val_var],
-                Implies(
-                    Term(ObjectPointerHasProperty.__name__, inst_var, slot_name, val_var), Term(PointerIsArray.__name__, val_var)
-                ),
-            )
-            yield Forall(
-                [val_var],
-                Implies(
-                    Term(ObjectPointerHasProperty.__name__, inst_var, slot_name, val_var),
-                    Term(InlinedObject.__name__, val_var, v),
-                ),
-            )
-        elif k == "inlined" and v is True:
-            yield Forall(
-                [val_var],
-                Implies(
-                    Term(ObjectPointerHasProperty.__name__, inst_var, slot_name, val_var),
-                    Term(InlinedObject.__name__, val_var, v),
-                ),
-            )
-        elif k == "transitive" and v is True:
-            val_var2 = Variable("v2")
-            yield Forall(
-                [val_var, val_var2],
-                Implies(
-                    And(
-                        Term(ObjectPointerHasPropertyScalarized.__name__, inst_var, slot_name, val_var),
-                        Term(ObjectPointerHasPropertyScalarized.__name__, val_var, slot_name, val_var2),
-                    ),
-                    Term(ObjectPointerHasPropertyScalarized.__name__, inst_var, slot_name, val_var2),
-                ),
-            )
+def _items(value: Any) -> Iterable[tuple[str, Mapping[str, Any]]]:
+    if not value:
+        return ()
+    if not isinstance(value, Mapping):
+        raise ValueError(f"Expected a mapping, got {type(value)}")
+    return ((str(k), v or {}) for k, v in value.items())
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]

--- a/src/typedlogic/integrations/frameworks/linkml/reasoning.py
+++ b/src/typedlogic/integrations/frameworks/linkml/reasoning.py
@@ -1,0 +1,328 @@
+"""Reasoning utilities for LinkML schemas and generated ABox constraints."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from importlib.resources import files
+from pathlib import Path
+from typing import Any, Union
+
+from typedlogic import And, Forall, Implies, NegationAsFailure, Or, PredicateDefinition, Term, Theory, Variable
+from typedlogic.datamodel import CardinalityConstraint, Sentence
+from typedlogic.integrations.frameworks.linkml import loader
+from typedlogic.parsers.tlog_parser import TLogMarkdownParser
+
+SchemaSource = Union[Mapping[str, Any], Theory]
+
+SCHEMA_RULES_RESOURCE = "linkml_schema_rules.tlog.md"
+ABOX_MACROS_RESOURCE = "linkml_abox_macros.tlog.md"
+
+PREDICATE_NAME_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class LinkMLSchemaCheck:
+    """Result of running the LinkML schema reasoning layer."""
+
+    satisfiable: bool
+    theory: Theory
+    materialized_facts: tuple[Term, ...] = ()
+    program: str = ""
+
+    @property
+    def valid(self) -> bool:
+        """Return whether the schema passed the closed-world schema constraints."""
+        return self.satisfiable
+
+
+def schema_rules_path() -> Path:
+    """Return the packaged schema preprocessing rule document path."""
+    return Path(str(files("typedlogic.integrations.frameworks.linkml").joinpath(SCHEMA_RULES_RESOURCE)))
+
+
+def abox_macro_rules_path() -> Path:
+    """Return the packaged ABox macro rule document path."""
+    return Path(str(files("typedlogic.integrations.frameworks.linkml").joinpath(ABOX_MACROS_RESOURCE)))
+
+
+def load_schema_rules() -> Theory:
+    """Load the clingo-compatible LinkML schema preprocessing rules."""
+    return TLogMarkdownParser().parse(schema_rules_path())
+
+
+def load_abox_macro_rules() -> Theory:
+    """
+    Load the HiLog-style LinkML ABox macro rules.
+
+    These rules document the compile-away layer and are parseable TLog, but they
+    are intentionally not sent directly to first-order/clingo targets because
+    they use variable predicate position.
+    """
+    return TLogMarkdownParser().parse(abox_macro_rules_path())
+
+
+def schema_theory_from_object(schema: Mapping[str, Any], include_schema_rules: bool = True) -> Theory:
+    """Build a theory containing LinkML TBox facts and, optionally, schema rules."""
+    theory = Theory(name="linkml_schema")
+    _merge_predicate_definitions(theory, _schema_predicate_definitions())
+    theory.ground_terms.extend(loader.generate_from_object(schema))
+    if include_schema_rules:
+        _merge_theory(theory, load_schema_rules())
+    return theory
+
+
+def materialize_schema(schema: SchemaSource, include_schema_rules: bool = True) -> LinkMLSchemaCheck:
+    """Run the LinkML schema reasoning layer and return materialized facts."""
+    from typedlogic.integrations.solvers.clingo.clingo_solver import ClingoSolver
+
+    theory = schema if isinstance(schema, Theory) else schema_theory_from_object(schema, include_schema_rules)
+    solver = ClingoSolver()
+    solver.add(theory)
+    program = solver.dump()
+    models = list(solver.models())
+    if not models:
+        return LinkMLSchemaCheck(satisfiable=False, theory=theory, program=program)
+    return LinkMLSchemaCheck(
+        satisfiable=True,
+        theory=theory,
+        materialized_facts=tuple(sorted(models[0].ground_terms, key=repr)),
+        program=program,
+    )
+
+
+def check_schema(schema: SchemaSource) -> bool:
+    """Return whether a LinkML schema satisfies the schema-level rules."""
+    return materialize_schema(schema).valid
+
+
+def compile_schema_to_abox(schema: SchemaSource) -> Theory:
+    """
+    Compile a LinkML schema into direct ABox rules.
+
+    The returned theory assumes ABox data is already represented using unary
+    class/type predicates and binary slot predicates, for example
+    ``Person(i)`` and ``name(i, v)``.
+    """
+    check = materialize_schema(schema)
+    if not check.valid:
+        raise ValueError("LinkML schema failed schema-level reasoning constraints")
+
+    facts = _facts_by_predicate(check.materialized_facts)
+    _validate_abox_predicate_names(facts)
+
+    theory = Theory(name="linkml_abox_constraints")
+    _merge_predicate_definitions(theory, _abox_predicate_definitions(facts))
+    _add_schema_metadata(theory, check)
+
+    for child, parent in sorted(_tuples(facts, "class_ancestor")):
+        _add_once(theory, _unary_rule(child, parent))
+
+    for cls, slot, range_name in sorted(_tuples(facts, "effective_range")):
+        _add_once(theory, _range_constraint(cls, slot, range_name))
+
+    for cls, slot, minimum in sorted(_tuples(facts, "effective_minimum_cardinality")):
+        minimum_int = int(minimum)
+        if minimum_int > 0:
+            _add_once(theory, _minimum_cardinality_constraint(cls, slot, minimum_int))
+
+    for cls, slot, maximum in sorted(_tuples(facts, "effective_maximum_cardinality")):
+        maximum_int = int(maximum)
+        if maximum_int >= 0:
+            _add_once(theory, _maximum_cardinality_constraint(cls, slot, maximum_int))
+
+    return theory
+
+
+def validate_abox(schema: SchemaSource, facts: Iterable[Term]) -> bool:
+    """Validate direct ABox facts against a LinkML schema using clingo."""
+    from typedlogic.integrations.solvers.clingo.clingo_solver import ClingoSolver
+
+    theory = compile_schema_to_abox(schema)
+    theory.ground_terms.extend(facts)
+    solver = ClingoSolver()
+    solver.add(theory)
+    return bool(solver.check().satisfiable)
+
+
+def _facts_by_predicate(facts: Iterable[Term]) -> dict[str, set[tuple[Any, ...]]]:
+    by_predicate: dict[str, set[tuple[Any, ...]]] = defaultdict(set)
+    for fact in facts:
+        by_predicate[str(fact.predicate)].add(tuple(fact.values))
+    return by_predicate
+
+
+def _tuples(facts: Mapping[str, set[tuple[Any, ...]]], predicate: str) -> set[tuple[Any, ...]]:
+    return facts.get(predicate, set())
+
+
+def _unary_rule(child: str, parent: str) -> Sentence:
+    instance = Variable("I")
+    return Forall([instance], Implies(Term(child, instance), Term(parent, instance)))
+
+
+def _range_constraint(cls: str, slot: str, range_name: str) -> Sentence:
+    instance = Variable("I")
+    value = Variable("V")
+    return Forall(
+        [instance, value],
+        Implies(
+            And(Term(cls, instance), Term(slot, instance, value), NegationAsFailure(Term(range_name, value))),
+            Or(),
+        ),
+    )
+
+
+def _minimum_cardinality_constraint(cls: str, slot: str, minimum: int) -> Sentence:
+    instance = Variable("I")
+    value = Variable("V")
+    slot_value = Term(slot, instance, value)
+    cardinality = CardinalityConstraint(slot_value, slot_value, maximum_number=minimum - 1)
+    return Forall(
+        [instance],
+        Implies(And(Term(cls, instance), cardinality), Or()),
+    )
+
+
+def _maximum_cardinality_constraint(cls: str, slot: str, maximum: int) -> Sentence:
+    instance = Variable("I")
+    value = Variable("V")
+    slot_value = Term(slot, instance, value)
+    cardinality = CardinalityConstraint(slot_value, slot_value, minimum_number=maximum + 1)
+    return Forall(
+        [instance],
+        Implies(And(Term(cls, instance), cardinality), Or()),
+    )
+
+
+def _validate_abox_predicate_names(facts: Mapping[str, set[tuple[Any, ...]]]) -> None:
+    names = set()
+    for predicate in ("class_definition", "type_definition", "enum_definition", "slot_definition"):
+        names.update(str(values[0]) for values in _tuples(facts, predicate))
+    invalid = sorted(name for name in names if not PREDICATE_NAME_PATTERN.fullmatch(name))
+    if invalid:
+        raise ValueError(
+            "LinkML class, type, enum, and slot names must be valid predicate identifiers for ABox compilation: "
+            + ", ".join(invalid)
+        )
+
+
+def _abox_predicate_definitions(facts: Mapping[str, set[tuple[Any, ...]]]) -> list[PredicateDefinition]:
+    definitions: list[PredicateDefinition] = []
+    unary_predicates = set()
+    for predicate in ("class_definition", "type_definition", "enum_definition"):
+        unary_predicates.update(str(values[0]) for values in _tuples(facts, predicate))
+    for predicate_name in sorted(unary_predicates):
+        definitions.append(PredicateDefinition(predicate_name, {"id": "str"}))
+    for slot_name, in sorted(_tuples(facts, "slot_definition")):
+        definitions.append(PredicateDefinition(str(slot_name), {"id": "str", "value": "str"}))
+    return definitions
+
+
+def _schema_predicate_definitions() -> list[PredicateDefinition]:
+    unary = [
+        "schema_definition",
+        "class_definition",
+        "slot_definition",
+        "type_definition",
+        "enum_definition",
+        "tree_root",
+        "slot_required",
+        "slot_required_false",
+        "slot_recommended",
+        "slot_recommended_false",
+        "slot_multivalued",
+        "slot_multivalued_false",
+        "slot_identifier",
+        "slot_identifier_false",
+        "slot_key",
+        "slot_key_false",
+        "slot_designates_type",
+        "slot_designates_type_false",
+        "slot_inlined",
+        "slot_inlined_false",
+        "slot_inlined_as_list",
+        "slot_inlined_as_list_false",
+        "slot_transitive",
+        "slot_transitive_false",
+    ]
+    binary = [
+        "is_a",
+        "mixin",
+        "class_slot",
+        "attribute",
+        "slot_range",
+        "slot_pattern",
+        "slot_minimum_cardinality",
+        "slot_maximum_cardinality",
+        "slot_exact_cardinality",
+        "slot_equals_string",
+        "slot_equals_number",
+        "slot_equals_expression",
+        "slot_equals_string_in",
+    ]
+    ternary = [
+        "slot_usage_range",
+        "slot_usage_pattern",
+        "slot_usage_minimum_cardinality",
+        "slot_usage_maximum_cardinality",
+        "slot_usage_exact_cardinality",
+        "slot_usage_equals_string",
+        "slot_usage_equals_number",
+        "slot_usage_equals_expression",
+        "slot_usage_equals_string_in",
+    ]
+    class_slot_unary = [
+        "slot_usage_required",
+        "slot_usage_required_false",
+        "slot_usage_recommended",
+        "slot_usage_recommended_false",
+        "slot_usage_multivalued",
+        "slot_usage_multivalued_false",
+        "slot_usage_identifier",
+        "slot_usage_identifier_false",
+        "slot_usage_key",
+        "slot_usage_key_false",
+        "slot_usage_designates_type",
+        "slot_usage_designates_type_false",
+        "slot_usage_inlined",
+        "slot_usage_inlined_false",
+        "slot_usage_inlined_as_list",
+        "slot_usage_inlined_as_list_false",
+        "slot_usage_transitive",
+        "slot_usage_transitive_false",
+        "slot_usage",
+    ]
+    definitions = [PredicateDefinition(name, {"id": "str"}) for name in unary]
+    definitions.extend(PredicateDefinition(name, {"left": "str", "right": "str"}) for name in binary)
+    definitions.extend(PredicateDefinition(name, {"left": "str", "middle": "str", "right": "str"}) for name in ternary)
+    definitions.extend(PredicateDefinition(name, {"class": "str", "slot": "str"}) for name in class_slot_unary)
+    return definitions
+
+
+def _merge_theory(target: Theory, source: Theory) -> None:
+    target.type_definitions.update(source.type_definitions)
+    _merge_predicate_definitions(target, source.predicate_definitions)
+    target.sentence_groups.extend(source.sentence_groups)
+    target.ground_terms.extend(source.ground_terms)
+
+
+def _merge_predicate_definitions(target: Theory, definitions: Iterable[PredicateDefinition]) -> None:
+    existing = {definition.predicate for definition in target.predicate_definitions}
+    for definition in definitions:
+        if definition.predicate not in existing:
+            target.predicate_definitions.append(definition)
+            existing.add(definition.predicate)
+
+
+def _add_once(theory: Theory, sentence: Sentence) -> None:
+    if repr(sentence) not in {repr(existing) for existing in theory.sentences}:
+        theory.add(sentence)
+
+
+def _add_schema_metadata(theory: Theory, check: LinkMLSchemaCheck) -> None:
+    if theory._annotations is None:
+        theory._annotations = {}
+    theory._annotations["linkml_schema_program"] = check.program

--- a/src/typedlogic/integrations/frameworks/linkml/validator.py
+++ b/src/typedlogic/integrations/frameworks/linkml/validator.py
@@ -1,24 +1,29 @@
-from typing import Type
+"""Validation helpers for direct LinkML ABox facts."""
 
-import typedlogic.integrations.frameworks.linkml.instance as inst
-import typedlogic.integrations.frameworks.linkml.loader as linkml_loader
-import typedlogic.theories.jsonlog.loader as jsonlog_loader
-from typedlogic import Theory
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Optional, Type
+
+from typedlogic import Term
+from typedlogic.integrations.frameworks.linkml.reasoning import compile_schema_to_abox
 from typedlogic.solver import Solver
 
 
-def validate(schema: dict, data: dict, solver_class: Type[Solver]) -> bool:
+def validate(schema: dict, facts: Iterable[Term], solver_class: Optional[Type[Solver]] = None) -> bool:
     """
-    Validate a JSON object against a LinkML schema using a specified solver.
+    Validate ABox facts against a LinkML schema.
 
-    :param schema:
-    :param data:
-    :param solver_class:
-    :return:
+    The facts are expected to use the direct compile-away convention:
+    class/type predicates are unary and slot predicates are binary, for example
+    ``Person("p1")`` and ``name("p1", "n1")``.
     """
-    theory = Theory()
-    theory.extend(linkml_loader.generate_from_object(schema))
-    theory.extend(jsonlog_loader.generate_from_object(data))
+    theory = compile_schema_to_abox(schema)
+    theory.ground_terms.extend(facts)
+    if solver_class is None:
+        from typedlogic.integrations.solvers.clingo.clingo_solver import ClingoSolver
+
+        solver_class = ClingoSolver
     solver = solver_class()
     solver.add(theory)
-    return not not solver.check().satisfiable
+    return bool(solver.check().satisfiable)

--- a/tests/test_frameworks/linkml/test_linkml.py
+++ b/tests/test_frameworks/linkml/test_linkml.py
@@ -22,6 +22,7 @@ from typedlogic.integrations.frameworks.linkml.reasoning import (
     schema_theory_from_object,
     validate_abox,
 )
+from typedlogic.integrations.frameworks.linkml.validator import validate as validate_with_legacy_entrypoint
 from typedlogic.integrations.solvers.clingo.clingo_solver import ClingoSolver
 
 runner = CliRunner()
@@ -78,6 +79,24 @@ def test_loader_emits_reified_tbox_facts_only() -> None:
     assert has_term(facts, "slot_required_false", "age")
     assert has_term(facts, "slot_usage_required", "Person", "age")
     assert not any(term.predicate == "InstSlotRequired" for term in facts)
+
+
+def test_loader_emits_type_enum_and_boolean_slot_expression_facts() -> None:
+    """Types, enums, and explicit false slot-expression values are represented as TBox facts."""
+    schema = {
+        "types": {"PositiveInteger": {"typeof": "integer"}},
+        "enums": {"Status": {"permissible_values": {"ACTIVE": {}, "INACTIVE": {}}}},
+        "slots": {"status": {"range": "Status", "required": False, "multivalued": False}},
+        "classes": {"Sample": {"slots": ["status"]}},
+    }
+
+    facts = list(loader.generate_from_object(schema))
+
+    assert has_term(facts, "type_definition", "PositiveInteger")
+    assert has_term(facts, "enum_definition", "Status")
+    assert has_term(facts, "is_a", "PositiveInteger", "integer")
+    assert has_term(facts, "slot_required_false", "status")
+    assert has_term(facts, "slot_multivalued_false", "status")
 
 
 def test_schema_rules_and_macro_rules_are_parseable_tlog_markdown() -> None:
@@ -139,6 +158,41 @@ def test_schema_reasoning_rejects_inconsistent_cardinality() -> None:
     }
 
     assert not check_schema(schema)
+
+
+def test_schema_reasoning_rejects_unknown_ranges() -> None:
+    """Slot ranges must refer to a declared class, type, enum, or primitive type."""
+    schema = {
+        "slots": {"status": {"range": "MissingEnum"}},
+        "classes": {"Sample": {"slots": ["status"]}},
+    }
+
+    assert not check_schema(schema)
+
+
+def test_schema_reasoning_materializes_mixin_slots_and_abox_hierarchy() -> None:
+    """Mixins participate in schema closure and direct ABox class materialization."""
+    schema = {
+        "slots": {"label": {"range": "string", "required": True}},
+        "classes": {
+            "NamedMixin": {"slots": ["label"]},
+            "Person": {"mixins": ["NamedMixin"]},
+        },
+    }
+    materialized = set(materialize_schema(schema).materialized_facts)
+
+    assert has_term(materialized, "class_parent", "Person", "NamedMixin")
+    assert has_term(materialized, "class_ancestor", "Person", "NamedMixin")
+    assert has_term(materialized, "effective_class_slot", "Person", "label")
+    assert not validate_abox(schema, [Term("Person", "p1")])
+    assert validate_abox(
+        schema,
+        [
+            Term("Person", "p1"),
+            Term("label", "p1", "l1"),
+            Term("string", "l1"),
+        ],
+    )
 
 
 def test_compile_schema_to_abox_rejects_required_slot_absence() -> None:
@@ -237,6 +291,79 @@ def test_slot_usage_range_overrides_global_slot_range() -> None:
     )
 
 
+def test_subclass_inherits_parent_slot_usage_range_and_required() -> None:
+    """Subclass induced slots inherit parent slot_usage refinements."""
+    schema = {
+        "slots": {"value": {"range": "string"}},
+        "classes": {
+            "Measurement": {
+                "slots": ["value"],
+                "slot_usage": {"value": {"range": "integer", "required": True}},
+            },
+            "DerivedMeasurement": {"is_a": "Measurement"},
+        },
+    }
+    materialized = set(materialize_schema(schema).materialized_facts)
+
+    assert has_term(materialized, "effective_range", "DerivedMeasurement", "value", "integer")
+    assert not has_term(materialized, "effective_range", "DerivedMeasurement", "value", "string")
+    assert has_term(materialized, "effective_required", "DerivedMeasurement", "value")
+    assert not validate_abox(schema, [Term("DerivedMeasurement", "m1")])
+    assert validate_abox(
+        schema,
+        [
+            Term("DerivedMeasurement", "m1"),
+            Term("value", "m1", "v1"),
+            Term("integer", "v1"),
+        ],
+    )
+    assert not validate_abox(
+        schema,
+        [
+            Term("DerivedMeasurement", "m1"),
+            Term("value", "m1", "v1"),
+            Term("string", "v1"),
+        ],
+    )
+
+
+def test_subclass_inherits_parent_slot_usage_multivalued_cardinality() -> None:
+    """Subclass induced slots inherit parent slot_usage cardinality and multivalued refinements."""
+    schema = {
+        "slots": {"code": {"range": "string"}},
+        "classes": {
+            "Sample": {
+                "slots": ["code"],
+                "slot_usage": {"code": {"multivalued": True, "minimum_cardinality": 2, "maximum_cardinality": 3}},
+            },
+            "DerivedSample": {"is_a": "Sample"},
+        },
+    }
+    materialized = set(materialize_schema(schema).materialized_facts)
+
+    assert has_term(materialized, "effective_multivalued", "DerivedSample", "code")
+    assert has_term(materialized, "effective_minimum_cardinality", "DerivedSample", "code", 2)
+    assert has_term(materialized, "effective_maximum_cardinality", "DerivedSample", "code", 3)
+    assert validate_abox(
+        schema,
+        [
+            Term("DerivedSample", "s1"),
+            Term("code", "s1", "c1"),
+            Term("code", "s1", "c2"),
+            Term("string", "c1"),
+            Term("string", "c2"),
+        ],
+    )
+    assert not validate_abox(
+        schema,
+        [
+            Term("DerivedSample", "s1"),
+            Term("code", "s1", "c1"),
+            Term("string", "c1"),
+        ],
+    )
+
+
 def test_compile_schema_to_abox_rejects_singlevalued_and_max_cardinality_violations() -> None:
     """Default single-valued slots and explicit maximum cardinalities become ABox constraints."""
     too_many_names = [
@@ -270,6 +397,54 @@ def test_compile_schema_to_abox_rejects_singlevalued_and_max_cardinality_violati
 
     assert not validate_abox(PERSON_SCHEMA, too_many_names)
     assert not validate_abox(PERSON_SCHEMA, too_many_aliases)
+
+
+def test_compile_schema_to_abox_supports_type_and_enum_ranges() -> None:
+    """ABox range checks work for LinkML type and enum definitions."""
+    schema = {
+        "types": {"PositiveInteger": {"typeof": "integer"}},
+        "enums": {"Status": {"permissible_values": {"ACTIVE": {}, "INACTIVE": {}}}},
+        "slots": {
+            "score": {"range": "PositiveInteger", "required": True},
+            "status": {"range": "Status", "required": True},
+        },
+        "classes": {"Sample": {"slots": ["score", "status"]}},
+    }
+
+    assert validate_abox(
+        schema,
+        [
+            Term("Sample", "s1"),
+            Term("score", "s1", "score1"),
+            Term("status", "s1", "status1"),
+            Term("PositiveInteger", "score1"),
+            Term("Status", "status1"),
+        ],
+    )
+    assert not validate_abox(
+        schema,
+        [
+            Term("Sample", "s1"),
+            Term("score", "s1", "score1"),
+            Term("status", "s1", "status1"),
+            Term("integer", "score1"),
+            Term("string", "status1"),
+        ],
+    )
+
+
+def test_compile_schema_to_abox_dump_contains_closed_world_aggregate_constraints() -> None:
+    """Generated ABox rules are concrete clingo constraints, not schema-level macros."""
+    schema = {
+        "slots": {"code": {"range": "string", "exact_cardinality": 2, "multivalued": True}},
+        "classes": {"Sample": {"slots": ["code"]}},
+    }
+    solver = ClingoSolver()
+    solver.add(compile_schema_to_abox(schema))
+    program = solver.dump()
+
+    assert ":- sample(I), {code(I, V) : code(I, V)} <= 1." in program
+    assert ":- sample(I), 3 <= {code(I, V) : code(I, V)}." in program
 
 
 def test_compile_schema_to_abox_enforces_exact_cardinality() -> None:
@@ -321,6 +496,21 @@ def test_compile_schema_to_abox_rejects_invalid_predicate_names() -> None:
 
     with pytest.raises(ValueError, match="valid predicate identifiers"):
         compile_schema_to_abox(schema)
+
+
+def test_validator_entrypoint_accepts_direct_abox_facts() -> None:
+    """The legacy validator module delegates to the direct ABox validation layer."""
+    schema = {"slots": {"name": {"required": True}}, "classes": {"Person": {"slots": ["name"]}}}
+
+    assert validate_with_legacy_entrypoint(
+        schema,
+        [
+            Term("Person", "p1"),
+            Term("name", "p1", "n1"),
+            Term("string", "n1"),
+        ],
+    )
+    assert not validate_with_legacy_entrypoint(schema, [Term("Person", "p1")])
 
 
 def test_linkml_parser_returns_schema_theory_with_rules(tmp_path: Path) -> None:

--- a/tests/test_frameworks/linkml/test_linkml.py
+++ b/tests/test_frameworks/linkml/test_linkml.py
@@ -1,280 +1,380 @@
-from typing import Any, Dict, Mapping, Type, Optional
+"""Tests for LinkML schema reasoning and ABox compile-away."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
 
 import pytest
-import typedlogic.integrations.frameworks.linkml.instance as inst
-import typedlogic.integrations.frameworks.linkml.loader as linkml_loader
-import typedlogic.theories.jsonlog.loader as jsonlog_loader
-from typedlogic import Fact, Theory
-from typedlogic.compiler import write_sentences
-from typedlogic.integrations.frameworks.linkml import ClassDefinition
-from typedlogic.integrations.frameworks.linkml.instance import PointerType
+from typer.testing import CliRunner
+
+from typedlogic import Term, Theory
+from typedlogic.cli import app
+from typedlogic.compilers.tlog_compiler import TLogCompiler
+from typedlogic.integrations.frameworks.linkml import loader
+from typedlogic.integrations.frameworks.linkml.linkml_parser import LinkMLParser
+from typedlogic.integrations.frameworks.linkml.reasoning import (
+    check_schema,
+    compile_schema_to_abox,
+    load_abox_macro_rules,
+    load_schema_rules,
+    materialize_schema,
+    schema_theory_from_object,
+    validate_abox,
+)
 from typedlogic.integrations.solvers.clingo.clingo_solver import ClingoSolver
-from typedlogic.integrations.solvers.prover9 import Prover9Solver
-from typedlogic.integrations.solvers.souffle import SouffleSolver
-from typedlogic.integrations.solvers.z3 import Z3Solver
-from typedlogic.parsers.pyparser.python_parser import PythonParser
-from typedlogic.solver import Solver
-from typedlogic.theories.jsonlog.jsonlog import PointerIsArray
 
-from tests import OUTPUT_DIR
+runner = CliRunner()
 
-def validate_data(schema: dict, data: dict, target_class: Optional[str] = None, solver_class: Type[Solver] = ClingoSolver) -> bool:
-    solver = solve_data(schema=schema, data=data, target_class=target_class, solver_class=solver_class)
-    sat = solver.check().satisfiable
-    if sat:
-        print(f"ENTAILED:")
-        write_sentences(solver.model().ground_terms)
-    return sat is None or sat
 
-def solve_data(schema: dict, data: dict, target_class: Optional[str] = None, solver_class: Type[Solver] = ClingoSolver) -> Solver:
-    """
-    Validate a JSON object against a LinkML schema using a specified solver.
+def has_term(terms: list[Term] | tuple[Term, ...] | set[Term], predicate: str, *values: Any) -> bool:
+    """Return whether terms contain the requested ground term."""
+    return Term(predicate, *values) in terms
 
-    :param schema:
-    :param data:
-    :param target_class: The class to validate against, if any
-    :param solver_class:
-    :return:
-    """
-    pp = PythonParser()
-    theory = pp.transform(inst)
-    theory.extend(linkml_loader.generate_from_object(schema))
-    theory.extend(jsonlog_loader.generate_from_object(data))
-    if target_class:
-        theory.add(inst.PointerType("/", target_class))
-    write_sentences(theory.sentences)
-    print("PROLOG:")
-    write_sentences(theory.sentences, "prolog")
-    solver = solver_class()
+
+def solve_with_facts(theory: Theory, *facts: Term) -> bool:
+    """Return clingo satisfiability after adding facts to a theory."""
+    theory.ground_terms.extend(facts)
+    solver = ClingoSolver()
     solver.add(theory)
-    print(solver.dump())
-    return solver
+    return bool(solver.check().satisfiable)
 
-DEFAULT_TYPES: Mapping[str, Dict[str, Any]] = {
-    "string": {},
-    "integer": {},
-}
 
-SCHEMA1 = {
+PERSON_SCHEMA = {
+    "id": "https://example.org/person",
+    "slots": {
+        "id": {"identifier": True, "range": "string", "required": True},
+        "name": {"range": "string", "required": True},
+        "age": {"range": "integer", "required": False},
+        "aliases": {"range": "string", "multivalued": True, "minimum_cardinality": 1, "maximum_cardinality": 2},
+    },
     "classes": {
-        "Thing": {},
+        "NamedThing": {"slots": ["id"]},
         "Person": {
-            "tree_root": True,
-            "is_a": "Thing",
-            "attributes": {
-                "name": {
-                    "identifier": True,
-                    "range": "string",
-                    "required": True,
-                    "multivalued": False,
-                },
-                "address": {
-                    "any_of": [
-                        {"range": "Address", "inlined": False},
-                        {"range": "string"},
-                    ],
-                },
-            },
+            "is_a": "NamedThing",
+            "slots": ["name", "age", "aliases"],
+            "slot_usage": {"age": {"required": True}},
         },
-        "Address": {
+        "Employee": {
+            "is_a": "Person",
             "attributes": {
-                "street": {
-                    "range": "string",
-                    "required": True,
-                    "multivalued": False,
-                },
+                "employee_id": {"range": "string", "required": True},
             },
         },
     },
 }
 
 
-@pytest.mark.parametrize(
-    "schema,data,valid,expected",
-    [
-        (
-            SCHEMA1,
-            {"name": "Bob"},
-            True,
-            [
-                inst.PointerType("/", "Thing"),
-                inst.PointerType("/", "Person"),
-                inst.PointerIsScalar("/name/"),
-                inst.ObjectPointerHasPropertyScalarized("/", "name", "/name/"),
-                # inst.PointerType("/name/", "string"),
-                (inst.PointerType("/name/", "string"), {Z3Solver}),  # todo: unroll nested foralls
-                # inst.InstanceSlotToValuePointer("/", "name", "Bob"),
-            ],
-        ),
-        (
-            SCHEMA1,
-            {"name": {"foo": "bar"}},
-            True,
-            [],
-            # True, # TODO
-            # [(inst.InstanceType("/name/", "string"), {Z3Solver})]
-        ),
-    ],
-)
-# @pytest.mark.parametrize("solver_class", [Z3Solver, SouffleSolver, ClingoSolver, Prover9Solver])
-@pytest.mark.parametrize("solver_class", [Z3Solver, SouffleSolver, ClingoSolver])
-def test_validate(solver_class, schema, data, valid, expected, request):
-    if solver_class == Z3Solver:
-        pytest.skip("Slow")
-    id = request.node.name
-    pp = PythonParser()
-    theory = pp.transform(inst)
-    if "types" not in schema:
-        schema["types"] = DEFAULT_TYPES
-    sentences = linkml_loader.generate_from_object(schema)
-    for s in sentences:
-        print(s)
-        theory.add(s)
-    sentences = jsonlog_loader.generate_from_object(data)
-    for s in sentences:
-        print(s)
-        theory.add(s)
+def test_loader_emits_reified_tbox_facts_only() -> None:
+    """The LinkML loader emits classic schema predicates, not Python-expanded ABox rules."""
+    facts = list(loader.generate_from_object(PERSON_SCHEMA))
 
-    solver = solver_class()
-    solver.add(theory)
-    if solver_class in [Z3Solver, ClingoSolver]:
-        assert solver.check().satisfiable is valid
-    with open(OUTPUT_DIR / f"v{id}.txt", "w") as f:
-        f.write(solver.dump())
-    # print(solver.dump())
-    model = solver.model()
-    for gt in model.ground_terms:
-        print(f"Ground term: {gt}")
-
-    expected = [e if isinstance(e, tuple) else (e, {solver_class}) for e in expected]
-    expected = [e[0] for e in expected if solver_class in e[1]]
-    expected = [e.to_model_object() for e in expected]
-    if solver_class in [Z3Solver, Prover9Solver]:
-        for e in expected:
-            assert solver.prove(e)
-    else:
-        assert not set(expected) - set(model.ground_terms)
+    assert has_term(facts, "schema_definition", "https://example.org/person")
+    assert has_term(facts, "class_definition", "Person")
+    assert has_term(facts, "slot_definition", "name")
+    assert has_term(facts, "class_slot", "Person", "name")
+    assert has_term(facts, "attribute", "Employee", "employee_id")
+    assert has_term(facts, "slot_required", "name")
+    assert has_term(facts, "slot_required_false", "age")
+    assert has_term(facts, "slot_usage_required", "Person", "age")
+    assert not any(term.predicate == "InstSlotRequired" for term in facts)
 
 
-def test_instance_data_model():
-    it = PointerType("P1", "Person")
-    assert isinstance(it, Fact)
-    l = PointerIsArray("P1")
-    cd = ClassDefinition("Person")
+def test_schema_rules_and_macro_rules_are_parseable_tlog_markdown() -> None:
+    """Both LinkML rule documents are authored outside Python as literate TLog."""
+    schema_rules = load_schema_rules()
+    macro_rules = load_abox_macro_rules()
 
-
-
-@pytest.mark.parametrize("solver_class", [ClingoSolver])
-@pytest.mark.parametrize("required", [False, True])
-@pytest.mark.parametrize("use_attributes", [False, True])
-@pytest.mark.parametrize("use_subclass", [False, True])
-@pytest.mark.parametrize(
-    "typ,val,valid",
-    [
-        (None, "hello", True),
-        (None, 42.1, True),
-        ("string", "hello", True),
-        ("string", None, True),
-        ("string", 42, False),
-        ("string", 42.1, False),
-        ("string", False, False),
-        ("integer", 42, True),
-        ("integer", "42", False),
-        ("integer", 42.2, False),
-        ("integer", False, False),
-    ],
-)
-# TODO
-def test_basic_types(typ: str, val: Any, valid: bool, use_subclass: bool, use_attributes: bool, required: bool, solver_class):
-    """
-    Test basic types
-    """
-    from typing import Dict, Any
-    schema: Dict[str, Any] = {
-        "slots": {
-            "s": {
-                "range": typ,
-                "required": required,
-            }
-        },
-        "classes": {
-            "C": {
-                "slots": ["s"],
-            }
-        },
+    assert schema_rules.predicate_definition_map["effective_class_slot"].arguments == {
+        "cls": "ElementID",
+        "slot": "SlotID",
     }
-    if use_attributes:
-        schema = {
-            "classes": {
-                "C": {
-                    "attributes": {
-                        "s": {
-                            "range": typ,
-                            "required": required,
-                        },
-                    },
-                }
-            },
-        }
-    if use_subclass:
-        schema["classes"]["D"] = {
-            "is_a": "C",
-            "slots": ["s2"],
-        }
-    data = {"s": val} if val is not None else {}
-    if required and val is None:
-        valid = False
-    inst_class = "D" if use_subclass else "C"
-    result = validate_data(schema, data, inst_class, solver_class)
-    assert result == valid, f"Expected {valid} but got {result} for {typ} with value {val}, req: {required}"
+    assert len(schema_rules.sentences) > 30
+    assert len(macro_rules.sentences) == 4
+    assert "@c(" in TLogCompiler().compile(macro_rules)
 
 
+def test_schema_reasoning_materializes_inheritance_defaults_and_overrides() -> None:
+    """Clingo preprocessing derives effective LinkML schema facts."""
+    check = materialize_schema(PERSON_SCHEMA)
+    facts = set(check.materialized_facts)
 
-@pytest.mark.parametrize("solver_class", [ClingoSolver])
-@pytest.mark.parametrize("transitive", [False, True])
-def test_transitive(transitive: bool, solver_class):
-    """
-    Test linkml transitive properties:
+    assert check.valid
+    assert has_term(facts, "class_ancestor", "Employee", "Person")
+    assert has_term(facts, "effective_class_slot", "Employee", "id")
+    assert has_term(facts, "effective_class_slot", "Employee", "employee_id")
+    assert has_term(facts, "effective_required", "Person", "age")
+    assert has_term(facts, "effective_range", "Employee", "employee_id", "string")
+    assert has_term(facts, "effective_maximum_cardinality", "Person", "name", 1)
+    assert has_term(facts, "effective_minimum_cardinality", "Person", "aliases", 1)
+    assert has_term(facts, "effective_maximum_cardinality", "Person", "aliases", 2)
 
-    If a slot s is transitive, and we have instances i s j, j s k, then we should be able to infer that i s k.
 
-    TODO: this requires references to work...
-    """
-    from typing import Dict, Any
-    schema: Dict[str, Any] = {
-        "slots": {
-            "id": {
-                "identifier": True,
-                "range": "string",
-            },
-            "s": {
-                "range": "C",
-                "transitive": transitive,
-            }
-        },
-        "classes": {
-            "Dataset": {
-                "attributes": {
-                    "objects": {
-                        "range": "C",
-                        "multivalued": True,
-                    },
-                },
-            },
-            "C": {
-                "slots": ["id", "s"],
-            }
-        },
+def test_schema_reasoning_rejects_is_a_cycles() -> None:
+    """The schema reasoning layer catches class is_a cycles."""
+    schema = {"classes": {"A": {"is_a": "B"}, "B": {"is_a": "A"}}}
+
+    assert not check_schema(schema)
+
+
+def test_schema_reasoning_rejects_missing_slot_definitions() -> None:
+    """Class slots must refer to declared or inline LinkML slots."""
+    schema = {"classes": {"Person": {"slots": ["name"]}}}
+
+    assert not check_schema(schema)
+
+
+def test_schema_reasoning_rejects_missing_parent_classes() -> None:
+    """Parent references are closed-world checked against declared classes."""
+    schema = {"classes": {"Person": {"is_a": "MissingParent"}}}
+
+    assert not check_schema(schema)
+
+
+def test_schema_reasoning_rejects_inconsistent_cardinality() -> None:
+    """Cardinality constraints are normalized and checked before ABox compilation."""
+    schema = {
+        "slots": {"name": {"minimum_cardinality": 2, "maximum_cardinality": 1}},
+        "classes": {"Person": {"slots": ["name"]}},
     }
-    dataset = {
-        "objects": [
-            {"id": "i", "s": "j"},
-            {"id": "j", "s": "k"},
-            {"id": "k"},
+
+    assert not check_schema(schema)
+
+
+def test_compile_schema_to_abox_rejects_required_slot_absence() -> None:
+    """Required slots compile to closed-world ABox aggregate constraints."""
+    theory = compile_schema_to_abox(PERSON_SCHEMA)
+    valid_facts = [
+        Term("Person", "p1"),
+        Term("id", "p1", "id1"),
+        Term("name", "p1", "n1"),
+        Term("age", "p1", "age1"),
+        Term("aliases", "p1", "a1"),
+        Term("string", "id1"),
+        Term("string", "n1"),
+        Term("integer", "age1"),
+        Term("string", "a1"),
+    ]
+
+    assert not solve_with_facts(theory, Term("Person", "p1"))
+    assert validate_abox(PERSON_SCHEMA, valid_facts)
+
+
+def test_compile_schema_to_abox_materializes_class_hierarchy() -> None:
+    """The compile-away layer generates direct unary class rules."""
+    theory = compile_schema_to_abox(PERSON_SCHEMA)
+    theory.ground_terms.extend(
+        [
+            Term("Employee", "e1"),
+            Term("id", "e1", "id1"),
+            Term("name", "e1", "n1"),
+            Term("employee_id", "e1", "eid1"),
+            Term("age", "e1", "age1"),
+            Term("aliases", "e1", "a1"),
+            Term("string", "id1"),
+            Term("string", "n1"),
+            Term("string", "eid1"),
+            Term("integer", "age1"),
+            Term("string", "a1"),
         ]
+    )
+
+    solver = ClingoSolver()
+    solver.add(theory)
+    assert solver.check().satisfiable
+    model = next(solver.models())
+    assert Term("Person", "e1") in model.ground_terms
+    assert Term("NamedThing", "e1") in model.ground_terms
+
+
+def test_compile_schema_to_abox_rejects_range_violations() -> None:
+    """Slot ranges compile to constraints over direct unary range predicates."""
+    facts = [
+        Term("Person", "p1"),
+        Term("id", "p1", "id1"),
+        Term("name", "p1", "n1"),
+        Term("age", "p1", "age1"),
+        Term("aliases", "p1", "a1"),
+        Term("string", "id1"),
+        Term("string", "n1"),
+        Term("string", "age1"),
+        Term("string", "a1"),
+    ]
+
+    assert not validate_abox(PERSON_SCHEMA, facts)
+
+
+def test_slot_usage_range_overrides_global_slot_range() -> None:
+    """Class-local slot usage refinements override global slot expressions."""
+    schema = {
+        "slots": {"value": {"range": "string"}},
+        "classes": {
+            "Measurement": {
+                "slots": ["value"],
+                "slot_usage": {"value": {"range": "integer", "required": True}},
+            }
+        },
     }
-    solver = solve_data(schema, dataset, "Dataset", solver_class)
-    for model in solver.models():
-        print(model)
-        for gt in model.iter_retrieve("Association"):
-            print(f"Ground term: {gt}")
+    materialized = set(materialize_schema(schema).materialized_facts)
+
+    assert has_term(materialized, "effective_range", "Measurement", "value", "integer")
+    assert not has_term(materialized, "effective_range", "Measurement", "value", "string")
+    assert validate_abox(
+        schema,
+        [
+            Term("Measurement", "m1"),
+            Term("value", "m1", "v1"),
+            Term("integer", "v1"),
+        ],
+    )
+    assert not validate_abox(
+        schema,
+        [
+            Term("Measurement", "m1"),
+            Term("value", "m1", "v1"),
+            Term("string", "v1"),
+        ],
+    )
+
+
+def test_compile_schema_to_abox_rejects_singlevalued_and_max_cardinality_violations() -> None:
+    """Default single-valued slots and explicit maximum cardinalities become ABox constraints."""
+    too_many_names = [
+        Term("Person", "p1"),
+        Term("id", "p1", "id1"),
+        Term("name", "p1", "n1"),
+        Term("name", "p1", "n2"),
+        Term("age", "p1", "age1"),
+        Term("aliases", "p1", "a1"),
+        Term("string", "id1"),
+        Term("string", "n1"),
+        Term("string", "n2"),
+        Term("integer", "age1"),
+        Term("string", "a1"),
+    ]
+    too_many_aliases = [
+        Term("Person", "p1"),
+        Term("id", "p1", "id1"),
+        Term("name", "p1", "n1"),
+        Term("age", "p1", "age1"),
+        Term("aliases", "p1", "a1"),
+        Term("aliases", "p1", "a2"),
+        Term("aliases", "p1", "a3"),
+        Term("string", "id1"),
+        Term("string", "n1"),
+        Term("integer", "age1"),
+        Term("string", "a1"),
+        Term("string", "a2"),
+        Term("string", "a3"),
+    ]
+
+    assert not validate_abox(PERSON_SCHEMA, too_many_names)
+    assert not validate_abox(PERSON_SCHEMA, too_many_aliases)
+
+
+def test_compile_schema_to_abox_enforces_exact_cardinality() -> None:
+    """Exact cardinality is normalized to matching minimum and maximum ABox constraints."""
+    schema = {
+        "slots": {"code": {"range": "string", "exact_cardinality": 2, "multivalued": True}},
+        "classes": {"Sample": {"slots": ["code"]}},
+    }
+    materialized = set(materialize_schema(schema).materialized_facts)
+
+    assert has_term(materialized, "effective_exact_cardinality", "Sample", "code", 2)
+    assert has_term(materialized, "effective_minimum_cardinality", "Sample", "code", 2)
+    assert has_term(materialized, "effective_maximum_cardinality", "Sample", "code", 2)
+    assert not validate_abox(
+        schema,
+        [
+            Term("Sample", "s1"),
+            Term("code", "s1", "c1"),
+            Term("string", "c1"),
+        ],
+    )
+    assert validate_abox(
+        schema,
+        [
+            Term("Sample", "s1"),
+            Term("code", "s1", "c1"),
+            Term("code", "s1", "c2"),
+            Term("string", "c1"),
+            Term("string", "c2"),
+        ],
+    )
+    assert not validate_abox(
+        schema,
+        [
+            Term("Sample", "s1"),
+            Term("code", "s1", "c1"),
+            Term("code", "s1", "c2"),
+            Term("code", "s1", "c3"),
+            Term("string", "c1"),
+            Term("string", "c2"),
+            Term("string", "c3"),
+        ],
+    )
+
+
+def test_compile_schema_to_abox_rejects_invalid_predicate_names() -> None:
+    """ABox compilation requires LinkML names that can be used as predicate identifiers."""
+    schema = {"slots": {"bad-slot": {"required": True}}, "classes": {"Person": {"slots": ["bad-slot"]}}}
+
+    with pytest.raises(ValueError, match="valid predicate identifiers"):
+        compile_schema_to_abox(schema)
+
+
+def test_linkml_parser_returns_schema_theory_with_rules(tmp_path: Path) -> None:
+    """The generic LinkML parser exposes schema facts and TLog schema rules."""
+    schema_path = tmp_path / "schema.yaml"
+    schema_path.write_text(
+        """
+id: https://example.org/parser
+slots:
+  name:
+    required: true
+classes:
+  Person:
+    slots:
+      - name
+""",
+        encoding="utf-8",
+    )
+
+    theory = LinkMLParser().parse(schema_path)
+
+    assert Term("class_definition", "Person") in theory.ground_terms
+    assert Term("slot_required", "name") in theory.ground_terms
+    assert "effective_required" in theory.predicate_definition_map
+    assert len(theory.sentences) > 30
+
+
+def test_generic_dump_cli_accepts_linkml_input_format(tmp_path: Path) -> None:
+    """The generic dump command can force LinkML parsing for .yaml schemas."""
+    schema_path = tmp_path / "schema.yaml"
+    schema_path.write_text(
+        """
+id: https://example.org/cli
+slots:
+  name:
+    required: true
+classes:
+  Person:
+    slots:
+      - name
+""",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["dump", str(schema_path), "-f", "linkml", "-t", "tlog"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "class_definition('Person')" in result.stdout
+    assert "effective_required" in result.stdout
+
+
+def test_schema_theory_without_rules_is_facts_only() -> None:
+    """Callers can request just the TBox fact layer."""
+    theory = schema_theory_from_object(PERSON_SCHEMA, include_schema_rules=False)
+
+    assert theory.sentences == []
+    assert Term("class_definition", "Person") in theory.ground_terms


### PR DESCRIPTION
## Summary
- Refactors the LinkML loader so schemas are emitted as reified TBox facts such as `class_definition/1`, `slot_definition/1`, `class_slot/2`, and slot-expression facts instead of Python-expanded ABox axioms.
- Adds a clingo-compatible literate TLog schema reasoning layer in `linkml_schema_rules.tlog.md` for inheritance, defaults, effective slots/ranges/cardinality, and schema-level constraints including `is_a` cycles.
- Adds a parseable HiLog-style macro document in `linkml_abox_macros.tlog.md` and a compile-away API that materializes schema facts, then emits direct ABox rules over `C/1` and `S/2` predicates.
- Adds direct ABox validation helpers, LinkML docs, and generic `typedlogic dump -f linkml` support.

## Validation
- `uv run ruff check src/typedlogic/integrations/frameworks/linkml/loader.py src/typedlogic/integrations/frameworks/linkml/reasoning.py src/typedlogic/integrations/frameworks/linkml/linkml_parser.py src/typedlogic/integrations/frameworks/linkml/validator.py src/typedlogic/integrations/frameworks/linkml/__init__.py src/typedlogic/cli.py tests/test_frameworks/linkml/test_linkml.py --select E501,I,F,W291,W293,D213,D104`
- `uv run --extra pandas --extra clingo pytest tests/test_frameworks/linkml/test_linkml.py tests/test_tlog_parser.py tests/test_parsers/test_catalog_parser.py tests/test_cli.py tests/test_tlog_cli.py -q`
- `uv run --extra pandas --extra clingo typedlogic dump tests/test_parsers/fixtures/schemas/person.yaml -f linkml -t tlog >/tmp/linkml-person.tlog`
- `uv build` and verified the wheel includes the packaged LinkML `.tlog.md` resources

Focused result: `147 passed, 2 skipped, 2 warnings`.

## Notes
- The compile-away layer requires LinkML class/type/enum/slot names to already be valid predicate identifiers. It raises instead of silently rewriting predicate names.
- This intentionally leaves JSON-log lowering as a separate problem; the new ABox API assumes direct unary/binary facts are already generated.