### PR TITLE
Optimize solver hot paths: sentence dedup, predicate index, prove() cleanup

### DIFF
--- a/src/typedlogic/datamodel.py
+++ b/src/typedlogic/datamodel.py
@@ -349,7 +349,7 @@ class Term(Sentence):
         Representation of the arguments of the term as a fixed-position tuples
         :return:
         """
-        return tuple([v for v in self.bindings.values()])
+        return tuple(self.bindings.values())
 
     @property
     def variables(self) -> List[Variable]:
@@ -554,6 +554,9 @@ class BooleanSentence(Sentence, ABC):
     def __eq__(self, other):
         return isinstance(other, type(self)) and self.operands == other.operands
 
+    def __hash__(self):
+        return hash((type(self), self.operands))
+
     def as_sexpr(self) -> SExpression:
         return [type(self).__name__] + [as_sexpr(op) for op in self.operands]
 
@@ -562,7 +565,7 @@ class BooleanSentence(Sentence, ABC):
         return list(self.operands)
 
 
-@dataclass
+@dataclass(eq=False)
 class And(BooleanSentence):
     """
     A conjunction of sentences.
@@ -594,7 +597,7 @@ class And(BooleanSentence):
         return f'And({", ".join(repr(op) for op in self.operands)})'
 
 
-@dataclass
+@dataclass(eq=False)
 class Or(BooleanSentence):
     """
     A disjunction of sentences.
@@ -628,7 +631,7 @@ class Or(BooleanSentence):
         return f'Or({", ".join(repr(op) for op in self.operands)})'
 
 
-@dataclass
+@dataclass(eq=False)
 class Not(BooleanSentence):
     """
     A complement of a sentence
@@ -677,7 +680,7 @@ class Xor(BooleanSentence):
         super().__init__(left, right, **kwargs)
 
 
-@dataclass
+@dataclass(eq=False)
 class ExactlyOne(BooleanSentence):
     """
     Exactly one of the sentences is true
@@ -697,7 +700,7 @@ class ExactlyOne(BooleanSentence):
         return f'ExactlyOne({", ".join(repr(op) for op in self.operands)})'
 
 
-@dataclass
+@dataclass(eq=False)
 class Implication(BooleanSentence, ABC):
     """
     An abstract grouping of sentences with an implication operator.
@@ -725,7 +728,7 @@ class Implication(BooleanSentence, ABC):
         return f"{type(self).__name__}({repr(self.operands[0])}, {repr(self.operands[1])})"
 
 
-@dataclass
+@dataclass(eq=False)
 class Implies(Implication):
     """
     An if-then implication.
@@ -763,7 +766,7 @@ class Implies(Implication):
         return f"Implies({repr(self.operands[0])}, {repr(self.operands[1])})"
 
 
-@dataclass
+@dataclass(eq=False)
 class Implied(Implication):
     """
     An implication of the form consequent <- antecedent
@@ -793,7 +796,7 @@ class Implied(Implication):
         return f"Implied({repr(self.operands[0])}, {repr(self.operands[1])})"
 
 
-@dataclass
+@dataclass(eq=False)
 class Iff(Implication):
     """
     An equivalence of sentences
@@ -827,7 +830,7 @@ class Iff(Implication):
         return f"Iff({repr(self.operands[0])}, {repr(self.operands[1])})"
 
 
-@dataclass
+@dataclass(eq=False)
 class NegationAsFailure(BooleanSentence):
     """
     A negated sentence, interpreted via negation as failure semantics.
@@ -889,7 +892,7 @@ class QuantifiedSentence(Sentence, ABC):
         return [self.variables, self.sentence]
 
 
-@dataclass
+@dataclass(eq=False)
 class Forall(QuantifiedSentence):
     """
     Universal quantifier.

--- a/src/typedlogic/integrations/solvers/souffle/souffle_solver.py
+++ b/src/typedlogic/integrations/solvers/souffle/souffle_solver.py
@@ -4,8 +4,9 @@ import subprocess
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import ClassVar, Iterator
+from typing import ClassVar, Dict, Iterator, List
 
+from typedlogic.datamodel import Term
 from typedlogic.integrations.solvers.souffle.souffle_compiler import SouffleCompiler
 from typedlogic.profiles import (
     AllowsComparisonTerms,
@@ -64,6 +65,9 @@ class SouffleSolver(Solver):
         pdmap = {}
 
         facts = []
+        terms_by_predicate: Dict[str, List[Term]] = {}
+        for term in self.base_theory.ground_terms:
+            terms_by_predicate.setdefault(term.predicate, []).append(term)
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create output directives for each predicate
             output_files = {}
@@ -79,9 +83,8 @@ class SouffleSolver(Solver):
                 program += f'\n.input {pred}(IO=file, filename="{input_file}")\n'
                 with open(input_file, "w", encoding="utf-8") as csvfile:
                     writer = csv.writer(csvfile, delimiter="\t")
-                    for term in self.base_theory.ground_terms:
-                        if term.predicate == pred:
-                            writer.writerow(term.bindings.values())
+                    for term in terms_by_predicate.get(pred, []):
+                        writer.writerow(term.bindings.values())
 
             with tempfile.NamedTemporaryFile(suffix=".dl", mode="w") as fp:
                 fp.write(program)

--- a/src/typedlogic/parsers/pyparser/python_parser.py
+++ b/src/typedlogic/parsers/pyparser/python_parser.py
@@ -132,8 +132,7 @@ class PythonParser(Parser):
                 source_module_name=module.__name__,
             )
         if isinstance(source, (TextIOWrapper, TextIO)):
-            lines = "\n".join(source.readlines())
-            return self.parse(lines, file_name=file_name, **kwargs)
+            return self.parse(source.read(), file_name=file_name, **kwargs)
         raise ValueError(f"Unsupported source type: {type(source)}")
 
     def validate_iter(

--- a/src/typedlogic/solver.py
+++ b/src/typedlogic/solver.py
@@ -3,7 +3,7 @@ from collections import abc
 from dataclasses import dataclass, field
 from pathlib import Path
 from types import ModuleType
-from typing import Any, ClassVar, Dict, Iterable, Iterator, List, Optional, TextIO, Tuple, Type, Union
+from typing import Any, ClassVar, Dict, Iterable, Iterator, List, Optional, Set, TextIO, Tuple, Type, Union
 
 from typedlogic import FactMixin, Variable
 from typedlogic.datamodel import (
@@ -37,9 +37,22 @@ class Model:
     description: Optional[str] = None
     source_object: Optional[Any] = None
     ground_terms: List[Term] = field(default_factory=list)
+    _predicate_index: Optional[Dict[str, List[Term]]] = field(default=None, init=False, repr=False, compare=False)
+    _indexed_count: int = field(default=0, init=False, repr=False, compare=False)
 
     def retrieve(self, predicate: Union[str, type], *args) -> List[Term]:
         return list(self.iter_retrieve(predicate, *args))
+
+    def _ensure_predicate_index(self) -> Dict[str, List[Term]]:
+        # the index is rebuilt if ground_terms has grown or shrunk; in-place
+        # replacement of a term at the same length is not detected
+        if self._predicate_index is None or self._indexed_count != len(self.ground_terms):
+            index: Dict[str, List[Term]] = {}
+            for t in self.ground_terms:
+                index.setdefault(t.predicate, []).append(t)
+            self._predicate_index = index
+            self._indexed_count = len(self.ground_terms)
+        return self._predicate_index
 
     def iter_retrieve(self, predicate: Union[str, type], *args) -> Iterator[Term]:
         """
@@ -50,15 +63,12 @@ class Model:
         """
         if isinstance(predicate, type):
             predicate = predicate.__name__
-        for t in self.ground_terms:
-            if t.predicate != predicate:
-                continue
+        for t in self._ensure_predicate_index().get(predicate, []):
             if args:
+                t_values = t.values
                 is_match = True
-                for i in range(len(args)):
-                    if args[i] is None:
-                        continue
-                    if args[i] != t.values[i]:
+                for i, arg in enumerate(args):
+                    if arg is not None and arg != t_values[i]:
                         is_match = False
                         break
                 if not is_match:
@@ -143,6 +153,8 @@ class Solver(ABC):
     type_definitions: Dict[str, str] = field(default_factory=dict)
     constants: Dict[str, Any] = field(default_factory=dict)
     goals: Optional[List[SentenceGroup]] = None
+    _sentences_added: Set[Sentence] = field(default_factory=set, init=False, repr=False, compare=False)
+    _unhashable_sentences_added: List[Sentence] = field(default_factory=list, init=False, repr=False, compare=False)
 
     @property
     def method(self) -> Method:
@@ -199,27 +211,24 @@ class Solver(ABC):
         if isinstance(sentence, Term):
             # Note: the default implementation may be highly ineffecient.
             # it is recommended to override this method in a subclass.
-            has_vars = sentence.variables
-            cls = type(self)
-            new_solver = cls()
-            new_solver.add(self.base_theory)
+            sentence_values = sentence.values
+            has_vars = any(isinstance(v, Variable) for v in sentence_values)
             model = self.model()
             for t in model.iter_retrieve(sentence.predicate):
                 if t == sentence:
                     return True
                 if has_vars:
-                    if t.predicate == sentence.predicate:
-                        is_match = True
-                        for i in range(len(sentence.values)):
-                            arg_val = sentence.values[i]
-                            if isinstance(arg_val, Variable):
-                                # auto-match (assume existential over whole domain)
-                                continue
-                            if arg_val != t.values[i]:
-                                is_match = False
-                                break
-                        if is_match:
-                            return True
+                    t_values = t.values
+                    is_match = True
+                    for arg_val, t_val in zip(sentence_values, t_values, strict=False):
+                        if isinstance(arg_val, Variable):
+                            # auto-match (assume existential over whole domain)
+                            continue
+                        if arg_val != t_val:
+                            is_match = False
+                            break
+                    if is_match:
+                        return True
             return False
         if isinstance(sentence, Exists):
             inner = sentence.sentence
@@ -273,11 +282,30 @@ class Solver(ABC):
             self.goals.append(sentence_group)
         if sentence_group.sentences:
             for sentence in sentence_group.sentences:
+                self._register_sentence(sentence)
                 self.add_sentence(sentence)
 
+    def _register_sentence(self, sentence: Sentence) -> bool:
+        """
+        Record a sentence as part of the base theory, returning True if it was already registered.
+
+        Sentences are tracked in a set; sentences embedding unhashable values
+        (e.g. raw fact objects in probabilistic terms) fall back to a linear scan.
+        """
+        try:
+            if sentence in self._sentences_added:
+                return True
+            self._sentences_added.add(sentence)
+        except TypeError:
+            if sentence in self._unhashable_sentences_added:
+                return True
+            self._unhashable_sentences_added.append(sentence)
+        return False
+
     def add_sentence(self, sentence: Sentence) -> None:
-        if sentence not in self.base_theory.sentences:
-            self.base_theory.sentence_groups.append(SentenceGroup(name="dynamic", sentences=[sentence]))
+        if self._register_sentence(sentence):
+            return
+        self.base_theory.sentence_groups.append(SentenceGroup(name="dynamic", sentences=[sentence]))
 
     def add_predicate_definition(self, predicate_definition: PredicateDefinition) -> None:
         """

--- a/tests/test_python_parser.py
+++ b/tests/test_python_parser.py
@@ -319,3 +319,40 @@ def test_parse_composable_gen_axiom():
     assert qs.variables[2].domain == "TreeNodeType"
     sentence = qs.sentence
     assert isinstance(sentence, Implies)
+
+
+MORTALS_SOURCE = '''
+from dataclasses import dataclass
+
+from typedlogic import FactMixin, axiom
+
+
+@dataclass
+class Person(FactMixin):
+    name: str
+
+
+@dataclass
+class Mortal(FactMixin):
+    name: str
+
+
+@axiom
+def all_persons_are_mortal(name: str):
+    """First line.
+    Second line."""
+    if Person(name):
+        assert Mortal(name)
+'''
+
+
+def test_parse_file_handle_preserves_line_breaks(tmp_path):
+    """Parsing from a file handle must not double line breaks (issue #30)."""
+    from typedlogic.parsers.pyparser.python_parser import PythonParser
+
+    path = tmp_path / "mortals_example.py"
+    path.write_text(MORTALS_SOURCE)
+    with path.open() as f:
+        theory = PythonParser().parse(f)
+    [sg] = [sg for sg in theory.sentence_groups if sg.name == "all_persons_are_mortal"]
+    assert sg.docstring == "First line.\nSecond line."

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,0 +1,141 @@
+"""Tests for the base Solver and Model classes."""
+
+from typing import Iterator
+
+import pytest
+
+from typedlogic import And, Implies, Not, Or, Variable
+from typedlogic.datamodel import Exists, SentenceGroup, Term
+from typedlogic.solver import Model, Solution, Solver
+
+X = Variable("x")
+P_X = Term("P", X)
+Q_X = Term("Q", X)
+
+
+class DummySolver(Solver):
+    """Minimal concrete solver: its model is just the ground terms added so far."""
+
+    def check(self) -> Solution:
+        return Solution(satisfiable=True)
+
+    def models(self) -> Iterator[Model]:
+        yield Model(ground_terms=list(self.base_theory.ground_terms))
+
+
+@pytest.mark.parametrize(
+    "sentence",
+    [
+        And(P_X, Q_X),
+        Or(P_X, Q_X),
+        Not(P_X),
+        Implies(P_X, Q_X),
+    ],
+)
+def test_boolean_sentences_are_hashable(sentence):
+    """Equal boolean sentences must be usable in sets/dicts with eq-consistent hashes."""
+    assert hash(sentence) == hash(type(sentence)(*sentence.operands))
+    assert len({sentence, type(sentence)(*sentence.operands)}) == 1
+
+
+def test_distinct_boolean_sentences_hash_into_distinct_set_entries():
+    assert len({And(P_X, Q_X), And(Q_X, P_X), Or(P_X, Q_X)}) == 3
+
+
+def test_add_sentence_deduplicates():
+    solver = DummySolver()
+    s = Implies(P_X, Q_X)
+    solver.add(s)
+    solver.add(s)
+    assert solver.base_theory.sentences == [s]
+    # an equal-but-distinct instance is also deduplicated
+    solver.add(Implies(P_X, Q_X))
+    assert solver.base_theory.sentences == [s]
+    # a different sentence is added
+    s2 = Implies(Q_X, P_X)
+    solver.add(s2)
+    assert solver.base_theory.sentences == [s, s2]
+
+
+def test_add_sentence_group_then_sentence_deduplicates():
+    solver = DummySolver()
+    s = Implies(P_X, Q_X)
+    solver.add(SentenceGroup(name="g", sentences=[s]))
+    assert solver.base_theory.sentences == [s]
+    solver.add(s)
+    assert solver.base_theory.sentences == [s]
+
+
+def test_add_many_sentences():
+    solver = DummySolver()
+    sentences = [Term("Edge", f"n{i}", f"n{i + 1}") for i in range(500)]
+    for s in sentences:
+        solver.add_sentence(s)
+    for s in sentences:
+        solver.add_sentence(s)
+    assert solver.base_theory.sentences == sentences
+
+
+class P:
+    """Stand-in predicate class for retrieve-by-type."""
+
+
+@pytest.fixture
+def model() -> Model:
+    return Model(
+        ground_terms=[
+            Term("P", "a", "b"),
+            Term("P", "c", "d"),
+            Term("Q", "e"),
+        ]
+    )
+
+
+def test_retrieve_by_predicate(model):
+    assert model.retrieve("P") == [Term("P", "a", "b"), Term("P", "c", "d")]
+    assert model.retrieve("Q") == [Term("Q", "e")]
+    assert model.retrieve("R") == []
+
+
+def test_retrieve_by_type(model):
+    assert model.retrieve(P) == [Term("P", "a", "b"), Term("P", "c", "d")]
+
+
+def test_retrieve_with_args(model):
+    assert model.retrieve("P", "a") == [Term("P", "a", "b")]
+    assert model.retrieve("P", None, "d") == [Term("P", "c", "d")]
+    assert model.retrieve("P", "a", "d") == []
+
+
+def test_retrieve_sees_terms_added_after_first_retrieve(model):
+    assert len(model.retrieve("P")) == 2
+    model.ground_terms.append(Term("P", "x", "y"))
+    assert len(model.retrieve("P")) == 3
+    assert len(model.retrieve("Q")) == 1
+
+
+def test_prove_ground_term():
+    solver = DummySolver()
+    solver.base_theory.ground_terms.extend([Term("P", "a", "b"), Term("Q", "e")])
+    assert solver.prove(Term("P", "a", "b")) is True
+    assert solver.prove(Term("P", "a", "zzz")) is False
+    assert solver.prove(Term("R", "a")) is False
+
+
+def test_prove_term_with_variables():
+    solver = DummySolver()
+    solver.base_theory.ground_terms.append(Term("P", "a", "b"))
+    assert solver.prove(Term("P", X, "b")) is True
+    assert solver.prove(Term("P", X, "zzz")) is False
+    assert solver.prove(Exists([X], Term("P", X, "b"))) is True
+
+
+def test_add_sentence_with_unhashable_values_deduplicates():
+    """Sentences embedding unhashable values (e.g. raw fact objects) must still dedup."""
+    solver = DummySolver()
+    s = Term("P", [1, 2])
+    solver.add(s)
+    solver.add(s)
+    assert solver.base_theory.sentences == [s]
+    solver.add(Term("P", [1, 2]))
+    assert solver.base_theory.sentences == [s]


### PR DESCRIPTION
## Summary

Fixes the highest-impact findings from the efficiency audit (#24, #25, #27, #30; partially #26).

- **#24 — O(n²) theory construction**: `Solver.add_sentence` deduplicated by rebuilding `Theory.sentences` (a flattening property) and linearly scanning it on every call. It now tracks added sentences in a set, with a linear-scan fallback for sentences embedding unhashable values (e.g. raw fact objects in probabilistic terms). Adding 3000 sentences: **2.18s → 0.005s** (~400×).
- **Hashability groundwork**: `@dataclass` on `And`/`Or`/`Not`/`Implies`/etc. and `Forall` silently generated a fresh `__eq__` and set `__hash__ = None`, shadowing parent hashes. These now use `@dataclass(eq=False)` and inherit the (new, eq-consistent) `BooleanSentence.__hash__` / existing `QuantifiedSentence.__hash__`.
- **#27 — predicate index on Model**: `iter_retrieve` scanned all ground terms per query. It now uses a lazily-built `predicate → terms` index, rebuilt if `ground_terms` changes length (covered by a mutation test). 300 filtered retrieves over 6000 terms: **0.29s → 0.19s**, with bigger wins the more predicates a model has. `SouffleSolver` similarly groups ground terms once instead of scanning all terms per predicate definition.
- **#25 — dead work in `prove()`**: the default implementation built a `new_solver`, copied the entire base theory into it, and never used it. Removed; `.values` tuple rebuilds are also hoisted out of the match loops.
- **#26 (partial)** — `Term.values` builds its tuple directly from `bindings.values()` (no intermediate list); hot loops hoist it. Full property caching is left open since `Term` is mutable.
- **#30 — parser bug**: `PythonParser.parse` on a file handle did `"\n".join(source.readlines())`, doubling every line break (observable in extracted docstrings and error line numbers). Now `source.read()`, with a regression test.

## Tests

- New `tests/test_solver.py`: boolean-sentence hashability (eq-consistent hashes, set semantics), `add_sentence` dedup (same instance, equal instance, via sentence groups, unhashable values), `retrieve` by predicate/type/args, index freshness after `ground_terms` mutation, and `prove()` with ground/variable/existential goals.
- New parser regression test for the doubled-newline bug (failed before the fix with `'First line.\n\nSecond line.'`).
- Full suite: **941 passed, 197 skipped, 0 failed** — same skip set as main; mypy output identical to main's baseline; doctests and codespell pass.

Fixes #24, fixes #25, fixes #27, fixes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)